### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,25 +1,44 @@
-name: Erlang CI
+name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: master
+    tags: '*'
   pull_request:
-    branches: [ master ]
+    branches: master
 
 jobs:
-  build:
+  CI:
     runs-on: ubuntu-latest
     container:
-      image: erlang:22.0.7
+      image: heliumsystems/builder-erlang:1
     steps:
-    - uses: actions/checkout@v2
-    - name: Install libs
-      run: apt-get update && apt-get install -y curl autoconf automake libtool flex bison libgmp-dev cmake build-essential emacs-nox libssl-dev
-    - name: Install Rust
-      run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust.sh && chmod +x rust.sh && ./rust.sh -y
-    - name: Install libsodium
-      run: git clone -b stable https://github.com/jedisct1/libsodium.git && cd libsodium && ./configure --prefix=/usr && make check && make install && cd ..
-    - name: Compile
-      run: make
-    - name: Run tests
-      run: make test
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Build
+        env:
+          SANITIZE_ERLANG_NIFS: 1
+        run: rebar3 compile
+
+      - name: Run CT tests
+        env:
+          # We turn off leak detection to reduce noise from leaking
+          # processes that rebar exec()s before it actually runs the
+          # tests.
+          ASAN_OPTIONS: detect_leaks=0
+        run: LD_PRELOAD="$(cc --print-file libasan.so)" rebar3 ct
+
+      - name: Run EUnit tests
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+        run: LD_PRELOAD="$(cc --print-file libasan.so)" rebar3 eunit
+
+      - name: Check formatting
+        run: rebar3 fmt --check
+
+      - name: Run Dialyzer
+        run: rebar3 dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -22,7 +22,21 @@ jobs:
       - name: Build
         env:
           SANITIZE_ERLANG_NIFS: 1
-        run: rebar3 compile
+        run: ./rebar3 compile
+      
+      - name: Check formatting
+        run: ./rebar3 fmt --verbose --check rebar.config && rebar3 fmt --verbose --check "{src,include,test}/**/*.{hrl,erl,app.src}" && rebar3 fmt --verbose --check "config/sys.{config,config.src}"
+      
+      - name: Run xref
+        run: ./rebar3 xref
+
+      - name: Run Dialyzer
+        run: ./rebar3 dialyzer
+
+      - name: Run EUnit tests
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+        run: LD_PRELOAD="$(cc --print-file libasan.so)" ./rebar3 eunit
 
       - name: Run CT tests
         env:
@@ -30,15 +44,4 @@ jobs:
           # processes that rebar exec()s before it actually runs the
           # tests.
           ASAN_OPTIONS: detect_leaks=0
-        run: LD_PRELOAD="$(cc --print-file libasan.so)" rebar3 ct
-
-      - name: Run EUnit tests
-        env:
-          ASAN_OPTIONS: detect_leaks=0
-        run: LD_PRELOAD="$(cc --print-file libasan.so)" rebar3 eunit
-
-      - name: Check formatting
-        run: rebar3 fmt --check
-
-      - name: Run Dialyzer
-        run: rebar3 dialyzer
+        run: LD_PRELOAD="$(cc --print-file libasan.so)" ./rebar3 ct

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,6 @@ RUN make
 
 ADD config/vm.args config/vm.args
 ADD config/sys.config.src config/sys.config.src
-RUN ./rebar3 release
+RUN make rel
 
-CMD ["_build/default/rel/packet_purchaser/bin/packet_purchaser", "foreground"]
+CMD ["make", "run"]

--- a/Makefile
+++ b/Makefile
@@ -12,22 +12,19 @@ compile:
 	$(REBAR) compile && $(REBAR) format
 
 clean:
-	$(REBAR) clean
+	git clean -dXfffffffffff
 
-test: compile
-	$(REBAR) as test do xref, eunit, ct && $(REBAR) dialyzer
-
-ci:
-	$(REBAR) dialyzer && ($(REBAR) as test do xref, eunit, ct || (mkdir -p artifacts; tar --exclude='./_build/test/lib' --exclude='./_build/test/plugins' -czf artifacts/$(CIBRANCH).tar.gz _build/test; false))
-
-typecheck:
-	$(REBAR) dialyzer
-
-cover:
-	$(REBAR) cover
+test:
+	$(REBAR) fmt --verbose --check rebar.config && \
+	$(REBAR) fmt --verbose --check "{src,include,test}/**/*.{hrl,erl,app.src}" && \
+	$(REBAR) fmt --verbose --check "config/sys.{config,config.src}" && \
+	$(REBAR) xref && \
+	$(REBAR) dialyzer && \
+	$(REBAR) eunit && \
+	$(REBAR) ct
 
 rel:
 	$(REBAR) release
 
 run:
-	_build/default/rel/packet-purchaser/bin/packet-purchaser foreground
+	_build/default/rel/packet_purchaser/bin/packet_purchaser foreground

--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
 {format, [
     {files, [
         "rebar.config",
-        "{src,include,test}/*.{hrl,erl,app.src}",
+        "{src,include,test}/**/*.{hrl,erl,app.src}",
         "config/sys.{config,config.src}"
     ]},
     {ignore, []},

--- a/rebar.config
+++ b/rebar.config
@@ -13,21 +13,12 @@
     {iso8601, ".*", {git, "https://github.com/erlsci/iso8601.git", {tag, "1.3.1"}}}
 ]}.
 
-{plugins, [rebar3_format, erlfmt]}.
+{plugins, [erlfmt]}.
 
-{format, [
-    {files, [
-        "src/**/*.erl",
-        "include/*.hrl",
-        "packet_purchaser.app.src",
-        "test/**/*.erl",
-        "test/**/*.hrl",
-        "config/sys.config",
-        "config/sys.config.src"
-    ]},
-    {ignore, []},
-    {formatter, erlfmt_formatter},
-    {options, #{print_width => 100, ignore_pragma => true}}
+{erlfmt, [
+    {files, "rebar.config"},
+    {files, "{src,include,test}/*.{hrl,erl,app.src}"},
+    {files, "test/utils/*.{hrl,erl}"}
 ]}.
 
 {xref_checks, [

--- a/rebar.config
+++ b/rebar.config
@@ -13,12 +13,17 @@
     {iso8601, ".*", {git, "https://github.com/erlsci/iso8601.git", {tag, "1.3.1"}}}
 ]}.
 
-{plugins, [erlfmt]}.
+{plugins, [rebar3_format, erlfmt]}.
 
-{erlfmt, [
-    {files, "rebar.config"},
-    {files, "{src,include,test}/*.{hrl,erl,app.src}"},
-    {files, "test/utils/*.{hrl,erl}"}
+{format, [
+    {files, [
+        "rebar.config",
+        "{src,include,test}/*.{hrl,erl,app.src}",
+        "config/sys.{config,config.src}"
+    ]},
+    {ignore, []},
+    {formatter, erlfmt_formatter},
+    {options, #{print_width => 100, ignore_pragma => true}}
 ]}.
 
 {xref_checks, [

--- a/test/end_to_end_SUITE.erl
+++ b/test/end_to_end_SUITE.erl
@@ -1,4 +1,4 @@
--module(end_to_end_TEST).
+-module(end_to_end_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
The current github CI workflow can not currently build this project because a rust nif can't find the rust toolchain. In addition to fixing that primary issue, this PR adds:

- formatting checks
- running tests with assdress sanitizer enabled (only affects ASan-aware c NIFs)
- runs dialyzer
