### PR TITLE
Use hex literals when clamping to 32 bits

### DIFF
--- a/src/lorawan_devaddr.erl
+++ b/src/lorawan_devaddr.erl
@@ -52,7 +52,7 @@ get_net_id(DevAddr, PrefixLength, NwkIDBits) ->
 
 -spec uint32(integer()) -> integer().
 uint32(Num) ->
-    Num band 4294967295.
+    Num band 16#FFFFFFFF.
 
 -ifdef(TEST).
 

--- a/src/state_channels/pp_sc_packet_handler.erl
+++ b/src/state_channels/pp_sc_packet_handler.erl
@@ -80,7 +80,7 @@ handle_packet(SCPacket, _PacketTime, Pid) ->
         MAC,
         #{
             time => iso8601:format(calendar:system_time_to_universal_time(Tmst, millisecond)),
-            tmst => Tmst band 4294967295,
+            tmst => Tmst band 16#FFFFFFFF,
             freq => blockchain_helium_packet_v1:frequency(Packet),
             rfch => 0,
             modu => <<"LORA">>,

--- a/test/pp_udp_worker_SUITE.erl
+++ b/test/pp_udp_worker_SUITE.erl
@@ -90,7 +90,7 @@ push_data(Config) ->
                         <<"rssi">> => erlang:trunc(maps:get(rssi, Opts)),
                         <<"size">> => erlang:byte_size(maps:get(payload, Opts)),
                         <<"time">> => fun erlang:is_binary/1,
-                        <<"tmst">> => maps:get(timestamp, Opts) band 4294967295,
+                        <<"tmst">> => maps:get(timestamp, Opts) band 16#FFFFFFFF,
                         <<"codr">> => <<"4/5">>,
                         <<"stat">> => 1,
                         <<"chan">> => 0
@@ -129,7 +129,7 @@ delay_push_data(Config) ->
                         <<"rssi">> => erlang:trunc(maps:get(rssi, Opts0)),
                         <<"size">> => erlang:byte_size(maps:get(payload, Opts0)),
                         <<"time">> => fun erlang:is_binary/1,
-                        <<"tmst">> => maps:get(timestamp, Opts0) band 4294967295,
+                        <<"tmst">> => maps:get(timestamp, Opts0) band 16#FFFFFFFF,
                         <<"codr">> => <<"4/5">>,
                         <<"stat">> => 1,
                         <<"chan">> => 0
@@ -158,7 +158,7 @@ delay_push_data(Config) ->
                         <<"rssi">> => erlang:trunc(maps:get(rssi, Opts1)),
                         <<"size">> => erlang:byte_size(maps:get(payload, Opts1)),
                         <<"time">> => fun erlang:is_binary/1,
-                        <<"tmst">> => maps:get(timestamp, Opts1) band 4294967295,
+                        <<"tmst">> => maps:get(timestamp, Opts1) band 16#FFFFFFFF,
                         <<"codr">> => <<"4/5">>,
                         <<"stat">> => 1,
                         <<"chan">> => 0
@@ -310,7 +310,7 @@ multi_hotspots(Config) ->
                         <<"rssi">> => erlang:trunc(maps:get(rssi, Opts1)),
                         <<"size">> => erlang:byte_size(maps:get(payload, Opts1)),
                         <<"time">> => fun erlang:is_binary/1,
-                        <<"tmst">> => maps:get(timestamp, Opts1) band 4294967295,
+                        <<"tmst">> => maps:get(timestamp, Opts1) band 16#FFFFFFFF,
                         <<"codr">> => <<"4/5">>,
                         <<"stat">> => 1,
                         <<"chan">> => 0
@@ -336,7 +336,7 @@ multi_hotspots(Config) ->
                         <<"rssi">> => erlang:trunc(maps:get(rssi, Opts2)),
                         <<"size">> => erlang:byte_size(maps:get(payload, Opts2)),
                         <<"time">> => fun erlang:is_binary/1,
-                        <<"tmst">> => maps:get(timestamp, Opts2) band 4294967295,
+                        <<"tmst">> => maps:get(timestamp, Opts2) band 16#FFFFFFFF,
                         <<"codr">> => <<"4/5">>,
                         <<"stat">> => 1,
                         <<"chan">> => 0


### PR DESCRIPTION
I always have to manually convert 4294967295 when looking at TMST clamping in order to check that it's the correct value. Hex literals make it a little easier.