### PR TITLE
Apply multiplier to when we no longer consider an sc open

### DIFF
--- a/src/state_channels/pp_sc_worker.erl
+++ b/src/state_channels/pp_sc_worker.erl
@@ -44,6 +44,7 @@
 ]).
 
 -define(SERVER, ?MODULE).
+-define(SC_CONSIDERED_FULL_MULT, 0.99).
 -define(SC_BUFFER, 15).
 -define(SC_EXPIRATION, 25).
 % budget 100 data credits
@@ -246,7 +247,8 @@ maybe_start_state_channel(#state{in_flight = [], open_sc_limit = Limit} = State)
     OpenedSCs = maps:filter(
         fun(_ID, {SC, _}) ->
             blockchain_state_channel_v1:state(SC) == open andalso
-                blockchain_state_channel_v1:total_dcs(SC) < blockchain_state_channel_v1:amount(SC)
+                blockchain_state_channel_v1:total_dcs(SC) <
+                    (blockchain_state_channel_v1:amount(SC) * ?SC_CONSIDERED_FULL_MULT)
         end,
         SCs
     ),


### PR DESCRIPTION
A state channel can get spent almost until depletion. If a restart
happens right around that time, there's a less than likely chance that
it will be spent all the way out, so will sit there as "open" refusing
to be considered "active" by the sc server. We can kick things along by
being a bit less precise about what we consider an "open" state channel.
If there's basically no DC left to spend, the sc is basically not open
and we need to open another.