### PR TITLE
fix timestamps

### DIFF
--- a/src/state_channels/pp_sc_packet_handler.erl
+++ b/src/state_channels/pp_sc_packet_handler.erl
@@ -44,7 +44,7 @@ handle_offer(Offer, _HandlerPid) ->
     Resp.
 
 -spec handle_packet(blockchain_state_channel_packet_v1:packet(), pos_integer(), pid()) -> ok.
-handle_packet(SCPacket, _PacketTime, Pid) ->
+handle_packet(SCPacket, PacketTime, Pid) ->
     Packet = blockchain_state_channel_packet_v1:packet(SCPacket),
     PubKeyBin = blockchain_state_channel_packet_v1:hotspot(SCPacket),
     Token = semtech_udp:token(),
@@ -55,7 +55,9 @@ handle_packet(SCPacket, _PacketTime, Pid) ->
         Token,
         MAC,
         #{
-            time => iso8601:format(calendar:system_time_to_universal_time(Tmst, millisecond)),
+            time => iso8601:format(
+                calendar:system_time_to_universal_time(PacketTime, millisecond)
+            ),
             tmst => Tmst band 16#FFFFFFFF,
             freq => blockchain_helium_packet_v1:frequency(Packet),
             rfch => 0,


### PR DESCRIPTION
Tmst is a local 32-bit counter and should not be used when creating a timestamp for these frames. Probably a mistake from here where Tmst is set by taking system time?

https://github.com/helium/packet-purchaser/blob/1976840bb8352f6f1caeaa6d9146c8773a3e315d/src/semtech_udp/semtech_udp.erl#L176