### PR TITLE
Schedule pull_data retry after missed ack

### DIFF
--- a/src/pp_udp_worker.erl
+++ b/src/pp_udp_worker.erl
@@ -137,10 +137,11 @@ handle_info(
     {noreply, State#state{pull_data = RefAndToken}};
 handle_info(
     ?PULL_DATA_TIMEOUT_TICK,
-    State
+    #state{pull_data_timer = PullDataTimer} = State
 ) ->
-    lager:debug("got a pull data timeout, ignoring missed pull_ack"),
+    lager:debug("got a pull data timeout, ignoring missed pull_ack [retry: ~p]", [PullDataTimer]),
     ok = pp_metrics:pull_ack_missed(State#state.address),
+    _ = schedule_pull_data(PullDataTimer),
     {noreply, State};
 handle_info(_Msg, State) ->
     lager:warning("rcvd unknown info msg: ~p, ~p", [_Msg, State]),

--- a/src/pp_xor_filter_worker.erl
+++ b/src/pp_xor_filter_worker.erl
@@ -73,7 +73,7 @@ handle_cast(_Msg, State) ->
     lager:warning("rcvd unknown cast msg: ~p", [_Msg]),
     {noreply, State}.
 
-handle_info(post_init, #state{chain = undefined} = State) ->
+handle_info(?POST_INIT_TICK, #state{chain = undefined} = State) ->
     case blockchain_worker:blockchain() of
         undefined ->
             ok = schedule_post_init(),

--- a/src/pp_xor_filter_worker.erl
+++ b/src/pp_xor_filter_worker.erl
@@ -203,7 +203,7 @@ terminate(_Reason, #state{}) ->
         | {update, non_neg_integer(), devices_dev_eui_app_eui()}
     ]}.
 should_update_filters(Chain, OUI, FilterToDevices) ->
-    case pp_integration:get_devices() of
+    try pp_integration:get_devices() of
         {error, _Reason} ->
             lager:error("failed to get device ~p", [_Reason]),
             noop;
@@ -235,6 +235,10 @@ should_update_filters(Chain, OUI, FilterToDevices) ->
                     ),
                     {Routing, [{update, Index, R ++ Added} | OtherUpdates]}
             end
+    catch
+        exit:{timeout, Err} ->
+            lager:error("failed to get devices from integration", [Err]),
+            noop
     end.
 
 -spec smallest_first([{any(), L1 :: list()} | {any(), any(), L1 :: list()}]) -> list().

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -59,6 +59,7 @@ init_per_testcase(TestCase, Config) ->
             ok
     end,
 
+    {ok, FakeLNSPid} = pp_lns:start_link(#{port => 1700, forward => self()}),
     {ok, _} = application:ensure_all_started(?APP),
 
     SwarmKey = filename:join([
@@ -74,7 +75,6 @@ init_per_testcase(TestCase, Config) ->
         [{PPPrivKey, PPPubKey}]
     ),
 
-    {ok, FakeLNSPid} = pp_lns:start_link(#{port => 1700, forward => self()}),
     {PubKeyBin, WorkerPid} = start_gateway(),
 
     DefaultEnv = application:get_all_env(?APP),


### PR DESCRIPTION
UDP worker used to stop after a missed ack. Then it was decided a missed
ack is mostly okay. But we never rescheduled future pull_datas after
missing an ack. here it is. Now we are.