### PR TITLE
Pull_Resp through single port

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -36,3 +36,6 @@ PP_CONSOLE_ENDPOINT=http://helium_roaming:4000/
 PP_CONSOLE_WS_ENDPOINT=ws://helium_roaming:4000/socket/packet_purchaser/websocket
 PP_CONSOLE_SECRET=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 PP_ENABLE_CONSOLE=false
+
+# Sending PULL_RESP to this port with special payload to save on ports
+PP_PULL_RESP_PORT=1703

--- a/config/sys.config
+++ b/config/sys.config
@@ -20,7 +20,8 @@
         {sc_expiration_interval, 25},
         {sc_expiration_buffer, 15},
         {pp_metrics_file, "/var/data/pp_metrics.dat"},
-        {pp_routing_config_file, "/var/data/routing_config.json"}
+        {pp_routing_config_file, "/var/data/routing_config.json"},
+        {pull_resp_port, 1703}
     ]},
     {blockchain, [
         {port, 2154},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -22,7 +22,8 @@
         {sc_open_dc_amount, "${PP_SC_OPEN_DC_AMOUNT}"},
         {sc_expiration_interval, "${PP_SC_EXPIRATION_INTERVAL}"},
         {sc_expiration_buffer, "${PP_SC_EXPIRATION_BUFFER}"},
-        {pp_routing_config_filename, "${PP_BASE_DIR}/${PP_ROUTING_CONFIG_FILE}"}
+        {pp_routing_config_filename, "${PP_BASE_DIR}/${PP_ROUTING_CONFIG_FILE}"},
+        {pull_resp_port, "${PP_PULL_RESP_PORT}"}
     ]},
     {blockchain, [
         {port, 2154},

--- a/config/test.config
+++ b/config/test.config
@@ -16,7 +16,8 @@
         ]},
         {sc_open_dc_amount, 100},
         {sc_expiration_interval, 25},
-        {pp_routing_config_filename, testing}
+        {pp_routing_config_filename, testing},
+        {pull_resp_port, 1703}
     ]},
     {blockchain, [
         {port, 2154}

--- a/src/pp_pull_resp.erl
+++ b/src/pp_pull_resp.erl
@@ -1,0 +1,165 @@
+-module(pp_pull_resp).
+
+-behavior(gen_server).
+
+-include("semtech_udp.hrl").
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+-export([
+    start_link/1,
+    get_port/1,
+    insert_sc_pid/2,
+    delete_sc_pid/1
+]).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Exports
+%% ------------------------------------------------------------------
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-define(SERVER, ?MODULE).
+-define(ETS, pp_pull_resp_ets).
+
+-record(state, {
+    socket :: gen_udp:socket(),
+    port :: inet:port_number()
+}).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+start_link(Args) ->
+    gen_server:start_link({local, ?SERVER}, ?SERVER, Args, []).
+
+-spec get_port(pid()) -> inet:port_number().
+get_port(Pid) ->
+    gen_server:call(Pid, get_port).
+
+-spec insert_sc_pid(MAC :: binary(), SCPid :: pid()) -> ok.
+insert_sc_pid(MAC, SCPid) ->
+    true = ets:insert(?ETS, {MAC, SCPid}),
+    ok.
+
+-spec delete_sc_pid(MAC :: binary()) -> ok.
+delete_sc_pid(MAC) ->
+    true = ets:delete(?ETS, MAC),
+    ok.
+
+-spec get_sc_pid_for_mac(MAC :: binary()) -> {ok, pid()} | {error, not_found}.
+get_sc_pid_for_mac(MAC) ->
+    case ets:lookup(?ETS, MAC) of
+        [{MAC, SCPid}] ->
+            case erlang:is_process_alive(SCPid) of
+                true -> {ok, SCPid};
+                false -> {error, not_found}
+            end;
+        [] ->
+            {error, not_found}
+    end.
+
+%% ------------------------------------------------------------------
+%% gen_server Function Definitions
+%% ------------------------------------------------------------------
+init(Args) ->
+    process_flag(trap_exit, true),
+    lager:info("~p init with ~p", [?SERVER, Args]),
+    Port = maps:get(port, Args),
+    {ok, Socket} = gen_udp:open(Port, [binary, {active, true}]),
+
+    ?ETS = ets:new(?ETS, [public, named_table, set]),
+
+    ct:print("started singleton ~p on ~p", [Socket, Port]),
+    {ok, #state{socket = Socket, port = Port}}.
+
+handle_call(get_port, _From, #state{port = Port} = State) ->
+    {reply, Port, State};
+handle_call(_Msg, _From, State) ->
+    lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    lager:warning("rcvd unknown cast msg: ~p", [_Msg]),
+    {noreply, State}.
+
+handle_info({udp, Socket, FromAddress, FromPort, Data}, #state{socket = Socket} = State) ->
+    ct:print("[~p:~p] got udp packet ~p", [FromAddress, FromPort, Data]),
+
+    case semtech_udp:identifier(Data) of
+        ?PULL_RESP ->
+            ok = handle_pull_resp(Data, Socket, FromAddress, FromPort);
+        ID ->
+            ID1 = semtech_udp:identifier_to_atom(ID),
+            ct:print("We don't handle (~p:~p)", [ID, ID1]),
+            throw(ID)
+    end,
+
+    {noreply, State};
+handle_info(_Msg, State) ->
+    lager:warning("rcvd unknown info msg: ~p, ~p", [_Msg, State]),
+    {noreply, State}.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, #state{socket = Socket}) ->
+    ok = gen_udp:close(Socket),
+    ok.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+-spec handle_pull_resp(
+    Data :: binary(),
+    Socket :: gen_udp:socket(),
+    Address :: inet:socket_address(),
+    Port :: inet:port_number()
+) -> ok.
+handle_pull_resp(Data, Socket, Address, Port) ->
+    {ok, Token, MAC, BinData} = semtech_udp:pull_resp_to_mac_data(Data),
+    ok = queue_downlink(MAC, BinData),
+    ok = send_tx_ack(Socket, Address, Port, Token, MAC),
+    ok.
+
+queue_downlink(MAC, BinData) ->
+    Map = maps:get(<<"txpk">>, BinData),
+    {ok, SCPid} = get_sc_pid_for_mac(MAC),
+
+    JSONData0 = maps:get(<<"data">>, Map),
+    JSONData1 =
+        try
+            base64:decode(JSONData0)
+        catch
+            _:_ ->
+                lager:warning("failed to decode pull_resp data ~p", [JSONData0]),
+                JSONData0
+        end,
+
+    DownlinkPacket = blockchain_helium_packet_v1:new_downlink(
+        JSONData1,
+        maps:get(<<"powe">>, Map),
+        maps:get(<<"tmst">>, Map),
+        maps:get(<<"freq">>, Map),
+        erlang:binary_to_list(maps:get(<<"datr">>, Map))
+    ),
+
+    catch blockchain_state_channel_common:send_response(
+        SCPid,
+        blockchain_state_channel_response_v1:new(true, DownlinkPacket)
+    ),
+    ok.
+
+send_tx_ack(Socket, Address, Port, Token, MAC) ->
+    OutData = semtech_udp:tx_ack(Token, MAC),
+    gen_udp:send(Socket, Address, Port, OutData),
+    ok.

--- a/src/pp_pull_resp.erl
+++ b/src/pp_pull_resp.erl
@@ -11,7 +11,8 @@
     start_link/1,
     get_port/1,
     insert_sc_pid/2,
-    delete_sc_pid/1
+    delete_sc_pid/1,
+    init_ets/0
 ]).
 
 %% ------------------------------------------------------------------
@@ -67,6 +68,11 @@ get_sc_pid_for_mac(MAC) ->
             {error, not_found}
     end.
 
+-spec init_ets() -> ok.
+init_ets() ->
+    ?ETS = ets:new(?ETS, [public, named_table, set]),
+    ok.
+
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
@@ -75,8 +81,6 @@ init(Args) ->
     lager:info("~p init with ~p", [?SERVER, Args]),
     Port = maps:get(port, Args),
     {ok, Socket} = gen_udp:open(Port, [binary, {active, true}]),
-
-    ?ETS = ets:new(?ETS, [public, named_table, set]),
 
     ct:print("started singleton ~p on ~p", [Socket, Port]),
     {ok, #state{socket = Socket, port = Port}}.

--- a/src/pp_sup.erl
+++ b/src/pp_sup.erl
@@ -71,6 +71,8 @@ init([]) ->
 
     {ok, ConfigFilename} = application:get_env(packet_purchaser, pp_routing_config_filename),
 
+    PullRespPort = pp_utils:get_env_int(pull_resp_port, 1703),
+
     ChildSpecs = [
         ?SUP(blockchain_sup, [BlockchainOpts]),
         ?WORKER(pp_config, [ConfigFilename]),
@@ -78,7 +80,8 @@ init([]) ->
         ?SUP(pp_udp_sup, []),
         ?SUP(pp_console_sup, []),
         ?WORKER(pp_metrics, []),
-        ?WORKER(pp_multi_buy, [])
+        ?WORKER(pp_multi_buy, []),
+        ?WORKER(pp_pull_resp, [#{port => PullRespPort}])
     ],
     {ok, {?FLAGS, ChildSpecs}}.
 

--- a/src/pp_sup.erl
+++ b/src/pp_sup.erl
@@ -72,6 +72,7 @@ init([]) ->
     {ok, ConfigFilename} = application:get_env(packet_purchaser, pp_routing_config_filename),
 
     PullRespPort = pp_utils:get_env_int(pull_resp_port, 1703),
+    ok = pp_pull_resp:init_ets(),
 
     ChildSpecs = [
         ?SUP(blockchain_sup, [BlockchainOpts]),

--- a/src/pp_utils.erl
+++ b/src/pp_utils.erl
@@ -7,7 +7,8 @@
     pubkeybin_to_mac/1,
     animal_name/1,
     calculate_dc_amount/1,
-    hex_to_binary/1
+    hex_to_binary/1,
+    get_env_int/2
 ]).
 
 -spec get_oui() -> undefined | non_neg_integer().
@@ -46,6 +47,14 @@ calculate_dc_amount(PayloadSize) ->
             blockchain_utils:calculate_dc_amount(Ledger, PayloadSize)
         end
     ).
+
+-spec get_env_int(atom(), integer()) -> integer().
+get_env_int(Key, Default) ->
+    case application:get_env(router, Key, Default) of
+        [] -> Default;
+        Str when is_list(Str) -> erlang:list_to_integer(Str);
+        I -> I
+    end.
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/semtech_udp/semtech_udp.erl
+++ b/src/semtech_udp/semtech_udp.erl
@@ -14,6 +14,8 @@
     pull_data/2,
     pull_ack/1,
     pull_resp/2,
+    pull_resp_to_mac/3,
+    pull_resp_to_mac_data/1,
     tx_ack/2, tx_ack/3,
     token/0,
     token/1,
@@ -104,6 +106,17 @@ pull_resp(Token, Map) ->
     BinJSX = jsx:encode(#{txpk => Map}, [{float_formatter, fun round_to_fourth_decimal/1}]),
     <<?PROTOCOL_2:8/integer-unsigned, Token/binary, ?PULL_RESP:8/integer-unsigned, BinJSX/binary>>.
 
+-spec pull_resp_to_mac(Token :: binary(), TargetMAC :: binary(), Data :: map()) -> binary().
+pull_resp_to_mac(Token, TargetMAC, Data) ->
+    BinJSX = jsx:encode(#{txpk => Data}, [{float_formatter, fun round_to_fourth_decimal/1}]),
+    <<
+        ?PROTOCOL_2:8/integer-unsigned,
+        Token/binary,
+        ?PULL_RESP:8/integer-unsigned,
+        TargetMAC:8/binary,
+        BinJSX/binary
+    >>.
+
 %%%-------------------------------------------------------------------
 %% @doc
 %% That packet type is used by the gateway to send a feedback to the server
@@ -177,6 +190,13 @@ json_data(
         BinJSX/binary>>
 ) ->
     jsx:decode(BinJSX).
+
+-spec pull_resp_to_mac_data(binary()) -> {ok, binary(), binary(), map()}.
+pull_resp_to_mac_data(
+    <<?PROTOCOL_2:8/integer-unsigned, Token:2/binary, ?PULL_RESP:8/integer-unsigned, MAC:8/binary,
+        BinJSX/binary>>
+) ->
+    {ok, Token, MAC, jsx:decode(BinJSX)}.
 
 %%====================================================================
 %% Internal functions

--- a/src/state_channels/pp_sc_worker.erl
+++ b/src/state_channels/pp_sc_worker.erl
@@ -439,27 +439,15 @@ get_nonce(PubkeyBin, Ledger) ->
 
 -spec get_sc_amount() -> pos_integer().
 get_sc_amount() ->
-    case application:get_env(?APP, sc_open_dc_amount, ?SC_AMOUNT) of
-        [] -> ?SC_AMOUNT;
-        Str when is_list(Str) -> erlang:list_to_integer(Str);
-        Amount -> Amount
-    end.
+    pp_utils:get_env_int(sc_open_dc_amount, ?SC_AMOUNT).
 
 -spec get_sc_expiration_interval() -> pos_integer().
 get_sc_expiration_interval() ->
-    case application:get_env(?APP, sc_expiration_interval, ?SC_EXPIRATION) of
-        [] -> ?SC_EXPIRATION;
-        Str when is_list(Str) -> erlang:list_to_integer(Str);
-        I -> I
-    end.
+    pp_utils:get_env_int(sc_expiration_interval, ?SC_EXPIRATION).
 
 -spec get_sc_buffer() -> pos_integer().
 get_sc_buffer() ->
-    case application:get_env(?APP, sc_expiration_buffer, ?SC_BUFFER) of
-        [] -> ?SC_BUFFER;
-        Str when is_list(Str) -> erlang:list_to_integer(Str);
-        I -> I
-    end.
+    pp_utils:get_env_int(sc_expiration_buffer, ?SC_BUFFER).
 
 -spec handle_sc_result(
     ok | {error, rejected | invalid},

--- a/test/pp_lns.erl
+++ b/test/pp_lns.erl
@@ -12,6 +12,7 @@
     delay_next_udp/2,
     delay_next_udp_forever/1,
     pull_resp/5,
+    pull_resp_to_mac/6,
     rcv/2, rcv/3,
     not_rcv/3,
     send_packet/2
@@ -53,6 +54,9 @@ delay_next_udp(Pid, Delay) ->
 
 pull_resp(Pid, IP, Port, Token, Map) ->
     gen_server:cast(Pid, {pull_resp, IP, Port, Token, Map}).
+
+pull_resp_to_mac(Pid, MAC, IP, Port, Token, Map) ->
+    gen_server:cast(Pid, {pull_resp_to_mac, MAC, IP, Port, Token, Map}).
 
 rcv(Pid, Type) ->
     rcv(Pid, Type, timer:seconds(1)).
@@ -126,6 +130,10 @@ handle_cast({delay_next_udp, Delay}, State) ->
 handle_cast({pull_resp, IP, Port, Token, Map}, #state{socket = Socket} = State) ->
     lager:info("pull_resp ~p", [{IP, Port, Token, Map}]),
     _ = gen_udp:send(Socket, IP, Port, semtech_udp:pull_resp(Token, Map)),
+    {noreply, State};
+handle_cast({pull_resp_to_mac, MAC, IP, Port, Token, Map}, #state{socket = Socket} = State) ->
+    lager:info("pull_resp to mac ~p", [{MAC, IP, Port, Token, Map}]),
+    _ = gen_udp:send(Socket, IP, Port, semtech_udp:pull_resp_to_mac(Token, MAC, Map)),
     {noreply, State};
 handle_cast(_Msg, State) ->
     lager:warning("rcvd unknown cast msg: ~p", [_Msg]),


### PR DESCRIPTION
Addresses #65 

Settings env var `PP_PULL_RESP_PORT` (default to `1703`) starts a udp worker that waits for a PULL_RESP frame with a MAC address. 

```
 Bytes  | Function
:------:|---------------------------------------------------------------------
 0      | protocol version = 2
 1-2    | random token
 3      | PULL_RESP identifier 0x03
 4-11   | Gateway unique identifier (MAC address)
 12-end  | JSON object, starting with {, ending with }, see section 6```
