### PR TITLE
Mj/start stop net id purchasing

### DIFF
--- a/src/apis/pp_console_ws_worker.erl
+++ b/src/apis/pp_console_ws_worker.erl
@@ -52,7 +52,8 @@
 -define(HEADER_JSON, {<<"Content-Type">>, <<"application/json">>}).
 
 %% Channels
--define(ORGANIZATION, <<"organization:all">>).
+-define(ORGANIZATION_CHANNEL, <<"organization:all">>).
+-define(NET_ID_CHANNEL, <<"net_id:all">>).
 
 %% Sending events
 -define(WS_SEND_GET_CONFIG, <<"packet_purchaser:get_config">>).
@@ -64,6 +65,8 @@
 -define(WS_RCV_CONFIG_LIST, <<"organization:all:config:list">>).
 -define(WS_RCV_REFILL_BALANCE, <<"organization:all:refill:dc_balance">>).
 -define(WS_RCV_DC_BALANCE_LIST, <<"organization:all:dc_balance:list">>).
+-define(WS_RCV_STOP_PURCHASING_NET_ID, <<"net_id:all:stop_purchasing">>).
+-define(WS_RCV_KEEP_PURCHASING_NET_ID, <<"net_id:all:keep_purchasing">>).
 
 -record(state, {
     ws :: undefind | pid(),
@@ -114,7 +117,7 @@ handle_packet(NetID, Packet, PacketTime, Type) ->
     },
 
     Ref = <<"0">>,
-    Topic = ?ORGANIZATION,
+    Topic = ?ORGANIZATION_CHANNEL,
     Event = ?WS_SEND_NEW_PACKET,
 
     Payload = pp_console_ws_handler:encode_msg(Ref, Topic, Event, Data),
@@ -126,7 +129,7 @@ send_address() ->
     B58 = libp2p_crypto:bin_to_b58(PubKeyBin),
     RouterAddressPayload = pp_console_ws_handler:encode_msg(
         <<"0">>,
-        ?ORGANIZATION,
+        ?ORGANIZATION_CHANNEL,
         ?WS_SEND_PP_ADDRESS,
         #{address => B58}
     ),
@@ -136,7 +139,7 @@ send_address() ->
 send_get_config() ->
     %% This will request ALL organizations configs.
     Ref = <<"0">>,
-    Topic = ?ORGANIZATION,
+    Topic = ?ORGANIZATION_CHANNEL,
     Event = ?WS_SEND_GET_CONFIG,
     Payload = pp_console_ws_handler:encode_msg(Ref, Topic, Event, #{}),
     ?MODULE:send(Payload).
@@ -145,7 +148,7 @@ send_get_config() ->
 send_get_org_balances() ->
     %% Get up to date balances for all orgs
     Ref = <<"0">>,
-    Topic = ?ORGANIZATION,
+    Topic = ?ORGANIZATION_CHANNEL,
     Event = ?WS_SEND_GET_ORG_BALANCES,
     Payload = pp_console_ws_handler:encode_msg(Ref, Topic, Event, #{}),
     ?MODULE:send(Payload).
@@ -246,25 +249,41 @@ terminate(_Reason, _State) ->
 %% ------------------------------------------------------------------
 %% Receive Message handler functions
 %% ------------------------------------------------------------------
-handle_message(?ORGANIZATION, ?WS_RCV_CONFIG_LIST, Payload) ->
+handle_message(?ORGANIZATION_CHANNEL, ?WS_RCV_CONFIG_LIST, Payload) ->
     lager:info("updating config: ~p", [Payload]),
     ok = pp_config:ws_update_config(Payload);
-handle_message(?ORGANIZATION, ?WS_RCV_DC_BALANCE_LIST, Payload) ->
+handle_message(?ORGANIZATION_CHANNEL, ?WS_RCV_DC_BALANCE_LIST, Payload) ->
     lager:info("updating dc balances: ~p", [Payload]),
     ok;
-handle_message(?ORGANIZATION, ?WS_RCV_REFILL_BALANCE, Payload) ->
+handle_message(?ORGANIZATION_CHANNEL, ?WS_RCV_REFILL_BALANCE, Payload) ->
     lager:info("refill DC balance: ~p", [Payload]),
+    ok;
+handle_message(?NET_ID_CHANNEL, ?WS_RCV_KEEP_PURCHASING_NET_ID, #{<<"net_ids">> := NetIDs}) ->
+    lager:info("keep purchasing: ~p", [NetIDs]),
+    ok;
+handle_message(?NET_ID_CHANNEL, ?WS_RCV_STOP_PURCHASING_NET_ID, #{<<"net_ids">> := NetIDs}) ->
+    lager:info("stop purchasing: ~p", [NetIDs]),
     ok;
 handle_message(Topic, Msg, Payload) ->
     case {Topic, Msg} of
-        {?ORGANIZATION, <<"phx_reply">>} ->
+        {?ORGANIZATION_CHANNEL, <<"phx_reply">>} ->
             lager:debug(
                 "organization websocket message [event: phx_reply] [payload: ~p]",
                 [Payload]
             );
-        {?ORGANIZATION, _} ->
+        {?ORGANIZATION_CHANNEL, _} ->
             lager:warning(
                 "rcvd unknown organization websocket message [event: ~p] [payload: ~p]",
+                [Msg, Payload]
+            );
+        {?NET_ID_CHANNEL, <<"phx_reply">>} ->
+            lager:debug(
+                "net_id websocket message [event: phx_reply] [payload: ~p]",
+                [Payload]
+            );
+        {?NET_ID_CHANNEL, _} ->
+            lager:warning(
+                "rcvd unknown net_id websocket message [event: ~p] [payload: ~p]",
                 [Msg, Payload]
             );
         {_, _} ->
@@ -303,7 +322,7 @@ start_ws(Endpoint, WSEndpoint, Secret) ->
             Url = binary_to_list(<<WSEndpoint/binary, "?token=", Token/binary, "&vsn=2.0.0">>),
             Args = #{
                 url => Url,
-                auto_join => [?ORGANIZATION],
+                auto_join => [?ORGANIZATION_CHANNEL, ?NET_ID_CHANNEL],
                 forward => self()
             },
             case pp_console_ws_handler:start_link(Args) of

--- a/src/apis/pp_console_ws_worker.erl
+++ b/src/apis/pp_console_ws_worker.erl
@@ -260,9 +260,11 @@ handle_message(?ORGANIZATION_CHANNEL, ?WS_RCV_REFILL_BALANCE, Payload) ->
     ok;
 handle_message(?NET_ID_CHANNEL, ?WS_RCV_KEEP_PURCHASING_NET_ID, #{<<"net_ids">> := NetIDs}) ->
     lager:info("keep purchasing: ~p", [NetIDs]),
+    ok = pp_config:start_buying(NetIDs),
     ok;
 handle_message(?NET_ID_CHANNEL, ?WS_RCV_STOP_PURCHASING_NET_ID, #{<<"net_ids">> := NetIDs}) ->
     lager:info("stop purchasing: ~p", [NetIDs]),
+    ok = pp_config:stop_buying(NetIDs),
     ok;
 handle_message(Topic, Msg, Payload) ->
     case {Topic, Msg} of

--- a/src/pp_config.erl
+++ b/src/pp_config.erl
@@ -59,7 +59,7 @@
     disable_pull_data :: boolean(),
     dev_eui :: '*' | non_neg_integer(),
     app_eui :: non_neg_integer(),
-    buying_active :: boolean()
+    buying_active = true :: boolean()
 }).
 
 -record(devaddr, {
@@ -69,7 +69,7 @@
     port :: non_neg_integer(),
     multi_buy :: unlimited | non_neg_integer(),
     disable_pull_data :: boolean(),
-    buying_active :: boolean()
+    buying_active = true :: boolean()
 }).
 
 -type config() :: #{joins := [#eui{}], routing := [#devaddr{}]}.

--- a/src/pp_config.erl
+++ b/src/pp_config.erl
@@ -12,7 +12,10 @@
     lookup_devaddr/1,
     %% UDP Cache
     insert_udp_worker/2,
-    delete_udp_worker/1
+    delete_udp_worker/1,
+    %% Purchasing
+    start_buying/1,
+    stop_buying/1
 ]).
 
 %% helper API
@@ -55,7 +58,8 @@
     multi_buy :: unlimited | non_neg_integer(),
     disable_pull_data :: boolean(),
     dev_eui :: '*' | non_neg_integer(),
-    app_eui :: non_neg_integer()
+    app_eui :: non_neg_integer(),
+    buying_active :: boolean()
 }).
 
 -record(devaddr, {
@@ -64,7 +68,8 @@
     address :: binary(),
     port :: non_neg_integer(),
     multi_buy :: unlimited | non_neg_integer(),
-    disable_pull_data :: boolean()
+    disable_pull_data :: boolean(),
+    buying_active :: boolean()
 }).
 
 -type config() :: #{joins := [#eui{}], routing := [#devaddr{}]}.
@@ -76,7 +81,9 @@
 start_link(Args) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [Args], []).
 
--spec lookup_eui(EUI) -> {ok, map()} | {error, unmapped_eui} when
+-spec lookup_eui(EUI) ->
+    {ok, map()} | {error, unmapped_eui} | {error, buying_inactive, NetID :: integer()}
+when
     EUI ::
         {eui, #eui_pb{}}
         | #eui_pb{}
@@ -95,6 +102,8 @@ lookup_eui({eui, DevEUI, AppEUI}) ->
     case ets:select(?EUI_ETS, Spec) of
         [] ->
             {error, unmapped_eui};
+        [#eui{buying_active = false, net_id = NetID}] ->
+            {error, buying_inactive, NetID};
         [
             #eui{
                 address = Address,
@@ -121,6 +130,8 @@ lookup_devaddr({devaddr, DevAddr}) ->
             case ets:lookup(?DEVADDR_ETS, NetID) of
                 [] ->
                     {error, routing_not_found};
+                [#devaddr{buying_active = false, net_id = NetID}] ->
+                    {error, buying_inactive, NetID};
                 [
                     #devaddr{
                         address = Address,
@@ -213,6 +224,22 @@ update_udp_workers(NetID, Address, Port) ->
     ],
     ok.
 
+-spec start_buying(NetIDs :: [integer()]) -> ok | {error, any()}.
+start_buying([]) ->
+    ok;
+start_buying([NetID | NetIDS]) ->
+    ok = update_buying_devaddr(NetID, true),
+    ok = update_buying_eui(NetID, true),
+    ?MODULE:start_buying(NetIDS).
+
+-spec stop_buying(NetIDs :: [integer()]) -> ok | {error, any()}.
+stop_buying([]) ->
+    ok;
+stop_buying([NetID | NetIDS]) ->
+    ok = update_buying_devaddr(NetID, false),
+    ok = update_buying_eui(NetID, false),
+    ?MODULE:stop_buying(NetIDS).
+
 %% -------------------------------------------------------------------
 %% gen_server Callbacks
 %% -------------------------------------------------------------------
@@ -268,6 +295,41 @@ init_ets() ->
         {write_concurrency, true},
         {read_concurrency, true}
     ]),
+    ok.
+
+-spec update_buying_devaddr(NetID :: integer(), BuyingActive :: boolean()) -> ok.
+update_buying_devaddr(NetID, BuyingActive) ->
+    DevaddrMS = ets:fun2ms(fun(#devaddr{net_id = Key} = Val) when Key == NetID ->
+        Val#devaddr{buying_active = BuyingActive}
+    end),
+    case ets:select_replace(?DEVADDR_ETS, DevaddrMS) of
+        1 ->
+            ok;
+        N ->
+            lager:warning(
+                "updating devaddr ets [net_id: ~p] [count: ~p] [buying_active_new_val: ~p] should be 1",
+                [NetID, N, BuyingActive]
+            )
+    end,
+    ok.
+
+-spec update_buying_eui(NetID :: integer(), BuyingActive :: boolean()) -> ok.
+update_buying_eui(NetID, BuyingActive) ->
+    %% There are potentially many EUIs per NetID. `ets:select_replace/2'
+    %% requires you keep the key intact, in a bag table the whole record is
+    %% considered as part of the key. So the current solution is to grab
+    %% everything we know of, delete it all, update the items for the NetID in
+    %% question and reinsert everything.
+    AllEuis = ets:tab2list(?EUI_ETS),
+    true = ets:delete_all_objects(?EUI_ETS),
+    NewEUIs = lists:map(
+        fun
+            (#eui{net_id = Key} = Val) when Key == NetID -> Val#eui{buying_active = BuyingActive};
+            (Val) -> Val
+        end,
+        AllEuis
+    ),
+    true = ets:insert(?EUI_ETS, NewEUIs),
     ok.
 
 -spec read_config(string()) -> list(map()).

--- a/src/state_channels/pp_sc_packet_handler.erl
+++ b/src/state_channels/pp_sc_packet_handler.erl
@@ -53,6 +53,8 @@ handle_packet(SCPacket, PacketTime, Pid) ->
                 ok = pp_console_ws_worker:handle_packet(NetID, Packet, PacketTime, packet),
                 pp_udp_worker:push_data(WorkerPid, SCPacket, PacketTime, Pid)
             catch
+                error:{badmatch, {error, buying_inactive, ErrNetID}} ->
+                    lager:warning("packet: buying disabled for ~p in net_id ~p", [DevAddr, ErrNetID]);
                 error:{badmatch, {error, routing_not_found}} ->
                     lager:warning("packet: routing information not found for packet ~p", [DevAddr]);
                 error:{badmatch, {error, worker_not_started, _Reason} = Error} ->
@@ -73,6 +75,8 @@ handle_packet(SCPacket, PacketTime, Pid) ->
                 ok = pp_console_ws_worker:handle_packet(NetID, Packet, PacketTime, join),
                 pp_udp_worker:push_data(WorkerPid, SCPacket, PacketTime, Pid)
             catch
+                error:{badmatch, {error, buying_inactive, ErrNetID}} ->
+                    lager:warning("join: buying disabled for ~p in net_id ~p", [EUI, ErrNetID]);
                 error:{badmatch, {error, unmapped_eui}} ->
                     lager:warning("join: no mapping for EUI ~p", [EUI]);
                 error:{badmatch, {error, routing_not_found}} ->

--- a/test/console_callback.erl
+++ b/test/console_callback.erl
@@ -16,13 +16,29 @@
     websocket_handle_event/3
 ]).
 
--export([update_config/2]).
+-export([
+    update_config/2,
+    start_buying/2,
+    stop_buying/2
+]).
 
 -define(UPDATE_CONFIG, update_config).
+-define(START_BUYING, start_buying).
+-define(STOP_BUYING, stop_buying).
 
 -spec update_config(pid(), list(map())) -> ok.
 update_config(WSPid, Config) ->
     WSPid ! {?UPDATE_CONFIG, Config},
+    ok.
+
+-spec start_buying(pid(), list(integer())) -> ok.
+start_buying(WSPid, NetIDs) ->
+    WSPid ! {?START_BUYING, NetIDs},
+    ok.
+
+-spec stop_buying(pid(), list(integer())) -> ok.
+stop_buying(WSPid, NetIDs) ->
+    WSPid ! {?STOP_BUYING, NetIDs},
     ok.
 
 init(Req, Args) ->
@@ -70,6 +86,22 @@ websocket_info(_Req, {?UPDATE_CONFIG, Map}, State) ->
         <<"organization:all">>,
         <<"organization:all:config:list">>,
         Map
+    ),
+    {reply, {text, Data}, State};
+websocket_info(_Req, {?START_BUYING, NetIDs}, State) ->
+    Data = pp_console_ws_handler:encode_msg(
+        <<"0">>,
+        <<"net_id:all">>,
+        <<"net_id:all:keep_purchasing">>,
+        #{net_ids => NetIDs}
+    ),
+    {reply, {text, Data}, State};
+websocket_info(_Req, {?STOP_BUYING, NetIDs}, State) ->
+    Data = pp_console_ws_handler:encode_msg(
+        <<"0">>,
+        <<"net_id:all">>,
+        <<"net_id:all:stop_purchasing">>,
+        #{net_ids => NetIDs}
     ),
     {reply, {text, Data}, State};
 websocket_info(_Req, _Msg, State) ->

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -232,7 +232,8 @@ ws_init() ->
         after 2500 -> ct:fail(websocket_init_timeout)
         end,
     %% Eat phx_join message and packet_purchaser address message
-    {ok, #{event := <<"phx_join">>}} = ws_roaming_rcv(),
+    {ok, #{event := <<"phx_join">>, topic := <<"organization:all">>}} = ws_roaming_rcv(),
+    {ok, #{event := <<"phx_join">>, topic := <<"net_id:all">>}} = ws_roaming_rcv(),
     {ok, #{event := <<"packet_purchaser:address">>}} = ws_roaming_rcv(),
     R.
 


### PR DESCRIPTION
Roaming-Console is managing DC for the time being. 
When a packet arrives at RC they if the org has no more DC, they will send a message of net_ids to stop purchasing. 
When DC is replenished, they will send the companion message to start purchasing for net_ids again.