### PR TITLE
The path towards websocket dominance

### DIFF
--- a/src/apis/pp_console_ws_worker.erl
+++ b/src/apis/pp_console_ws_worker.erl
@@ -228,7 +228,7 @@ handle_info(
 handle_info(ws_joined, #state{} = State) ->
     lager:info("joined, sending packet_purchaser address to console"),
     ok = ?MODULE:send_address(),
-    ok = ?MODULE:send_get_config(),
+    %% ok = ?MODULE:send_get_config(),
     %% TODO: dc tracker
     %% ok = ?MODULE:send_get_org_balances(),
     {noreply, State};

--- a/src/state_channels/pp_sc_packet_handler.erl
+++ b/src/state_channels/pp_sc_packet_handler.erl
@@ -37,7 +37,8 @@ handle_offer(Offer, _HandlerPid) ->
     end),
     Resp.
 
--spec handle_packet(blockchain_state_channel_packet_v1:packet(), pos_integer(), pid()) -> ok | {error, any()}.
+-spec handle_packet(blockchain_state_channel_packet_v1:packet(), pos_integer(), pid()) ->
+    ok | {error, any()}.
 handle_packet(SCPacket, PacketTime, Pid) ->
     Packet = blockchain_state_channel_packet_v1:packet(SCPacket),
     PubKeyBin = blockchain_state_channel_packet_v1:hotspot(SCPacket),


### PR DESCRIPTION
- fix formatting leftover from previous expedited PR.
- Don't request config from roaming-console on startup
   - will allow roaming-servers to startup with their ws connections active
   - packet-purchaser is still in charge of the config until further notice