### PR TITLE
Safe websocket startup

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -35,7 +35,7 @@ PP_ROUTING_CONFIG_FILE=routing_config.json
 PP_CONSOLE_ENDPOINT=http://helium_roaming:4000/
 PP_CONSOLE_WS_ENDPOINT=ws://helium_roaming:4000/socket/packet_purchaser/websocket
 PP_CONSOLE_SECRET=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-PP_ENABLE_CONSOLE=false
+PP_CONSOLE_ENABLE=false
 PP_CONSOLE_UPDATE_FROM_WS_CONFIG=false
 
 ## Keep from being relayed

--- a/config/sys.config
+++ b/config/sys.config
@@ -14,7 +14,7 @@
             {endpoint, <<>>},
             {ws_endpoint, <<>>},
             {secret, <<>>},
-            {is_active, false}
+            {auto_connect, false}
         ]},
         {update_from_ws_config, false},
         {sc_open_dc_amount, 100},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -17,7 +17,7 @@
             {endpoint, <<"${PP_CONSOLE_ENDPOINT}">>},
             {ws_endpoint, <<"${PP_CONSOLE_WS_ENDPOINT}">>},
             {secret, <<"${PP_CONSOLE_SECRET}">>},
-            {is_active, "${PP_ENABLE_CONSOLE}"}
+            {auto_connect, "${PP_CONSOLE_ENABLE}"}
         ]},
         {update_from_ws_config, "${PP_CONSOLE_UPDATE_FROM_WS_CONFIG}"},
         {sc_open_dc_amount, "${PP_SC_OPEN_DC_AMOUNT}"},

--- a/src/apis/pp_console_sup.erl
+++ b/src/apis/pp_console_sup.erl
@@ -39,7 +39,7 @@ init([]) ->
     {ok,
         {?FLAGS, [
             ?WORKER(pp_console_ws_worker, [ConsoleAPIConfig]),
-            ?WORKER(pp_console_ws_monitor, [ConsoleAPIConfig])
+            ?WORKER(pp_console_ws_manager, [ConsoleAPIConfig])
         ]}}.
 
 %%====================================================================

--- a/src/apis/pp_console_sup.erl
+++ b/src/apis/pp_console_sup.erl
@@ -18,7 +18,7 @@
 }).
 
 -define(FLAGS, #{
-    strategy => rest_for_one,
+    strategy => one_for_one,
     intensity => 1,
     period => 5
 }).
@@ -38,7 +38,8 @@ init([]) ->
     ConsoleAPIConfig = maps:from_list(application:get_env(packet_purchaser, pp_console_api, [])),
     {ok,
         {?FLAGS, [
-            ?WORKER(pp_console_ws_worker, [ConsoleAPIConfig])
+            ?WORKER(pp_console_ws_worker, [ConsoleAPIConfig]),
+            ?WORKER(pp_console_ws_monitor, [ConsoleAPIConfig])
         ]}}.
 
 %%====================================================================

--- a/src/apis/pp_console_ws_client.erl
+++ b/src/apis/pp_console_ws_client.erl
@@ -196,5 +196,5 @@ handle_message(#{topic := Topic, event := Event, payload := Payload}, #state{} =
     ok = pp_console_ws_worker:ws_handle_message(Topic, Event, Payload),
     {ok, State};
 handle_message(_Msg, State) ->
-    lager:debug("unhandle message ~p", [_Msg]),
+    lager:debug("unhandled message ~p", [_Msg]),
     {ok, State}.

--- a/src/apis/pp_console_ws_manager.erl
+++ b/src/apis/pp_console_ws_manager.erl
@@ -192,4 +192,4 @@ start_ws(WSEndpoint, Token) ->
         auto_join => [?ORGANIZATION_TOPIC, ?NET_ID_TOPIC],
         forward => self()
     },
-    pp_console_ws_handler:start_link(Args).
+    pp_console_ws_client:start_link(Args).

--- a/src/apis/pp_console_ws_manager.erl
+++ b/src/apis/pp_console_ws_manager.erl
@@ -1,12 +1,11 @@
 %%%-------------------------------------------------------------------
 %% @doc
-%% == Packet Purchaser Console WS Monitor ==
-%%
-%% - Restarts websocket connection if it goes down
+%% == Packet Purchaser Console WS Manager ==
+%% - Gets the console token with a backoff
 %%
 %% @end
 %%%-------------------------------------------------------------------
--module(pp_console_ws_monitor).
+-module(pp_console_ws_manager).
 
 -behavior(gen_server).
 

--- a/src/apis/pp_console_ws_manager.erl
+++ b/src/apis/pp_console_ws_manager.erl
@@ -1,7 +1,9 @@
 %%%-------------------------------------------------------------------
 %% @doc
 %% == Packet Purchaser Console WS Manager ==
+%%
 %% - Gets the console token with a backoff
+%% - Starts websocket connection when token is received successfully
 %%
 %% @end
 %%%-------------------------------------------------------------------

--- a/src/apis/pp_console_ws_manager.erl
+++ b/src/apis/pp_console_ws_manager.erl
@@ -78,14 +78,18 @@ init(Args) ->
     Endpoint = maps:get(endpoint, Args),
     Secret = maps:get(secret, Args),
     Backoff = backoff:type(backoff:init(?BACKOFF_MIN, ?BACKOFF_MAX), normal),
-    {ok,
-        #state{
-            http_endpoint = Endpoint,
-            secret = Secret,
-            ws_endpoint = WSEndpoint,
-            backoff = Backoff
-        },
-        {continue, ?GET_TOKEN}}.
+    State = #state{
+        http_endpoint = Endpoint,
+        secret = Secret,
+        ws_endpoint = WSEndpoint,
+        backoff = Backoff
+    },
+    case maps:get(auto_connect, Args, false) of
+        true ->
+            {ok, State, {continue, ?GET_TOKEN}};
+        false ->
+            {ok, State}
+    end.
 
 handle_continue(?GET_TOKEN, #state{} = State) ->
     %% For use during initialization.

--- a/src/apis/pp_console_ws_manager.erl
+++ b/src/apis/pp_console_ws_manager.erl
@@ -44,11 +44,11 @@
 -define(START_WS_CONNECTION, start_ws_connection).
 
 -record(state, {
-    ws = undefined :: pid(),
+    ws = undefined :: undefined | pid(),
     http_endpoint :: binary(),
     secret :: binary(),
     ws_endpoint :: binary(),
-    token = undefined :: binary(),
+    token = undefined :: undefined | binary(),
     backoff :: backoff:backoff(),
     backoff_timer :: undefined | reference()
 }).

--- a/src/apis/pp_console_ws_manager.erl
+++ b/src/apis/pp_console_ws_manager.erl
@@ -35,10 +35,6 @@
 -define(POOL, router_console_api_pool).
 -define(HEADER_JSON, {<<"Content-Type">>, <<"application/json">>}).
 
-%% Topics
--define(ORGANIZATION_TOPIC, <<"organization:all">>).
--define(NET_ID_TOPIC, <<"net_id:all">>).
-
 -define(BACKOFF_MIN, timer:seconds(2)).
 -define(BACKOFF_MAX, timer:minutes(1)).
 
@@ -193,7 +189,7 @@ start_ws(WSEndpoint, Token) ->
     Url = binary_to_list(<<WSEndpoint/binary, "?token=", Token/binary, "&vsn=2.0.0">>),
     Args = #{
         url => Url,
-        auto_join => [?ORGANIZATION_TOPIC, ?NET_ID_TOPIC],
+        auto_join => pp_console_ws_worker:ws_get_auto_join_topics(),
         forward => self()
     },
     pp_console_ws_client:start_link(Args).

--- a/src/apis/pp_console_ws_monitor.erl
+++ b/src/apis/pp_console_ws_monitor.erl
@@ -1,0 +1,136 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == Packet Purchaser Console WS Monitor ==
+%%
+%% - Restarts websocket connection if it goes down
+%%
+%% @end
+%%%-------------------------------------------------------------------
+-module(pp_console_ws_monitor).
+
+-behavior(gen_server).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+-export([
+    start_link/1,
+    start_ws_connection/0
+]).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Exports
+%% ------------------------------------------------------------------
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    handle_continue/2,
+    terminate/2,
+    code_change/3
+]).
+
+-define(SERVER, ?MODULE).
+
+-define(BACKOFF_MIN, timer:seconds(10)).
+-define(BACKOFF_MAX, timer:minutes(5)).
+-define(START_WS_CONNECTION, start_ws_connection).
+
+-record(state, {
+    auto_connect :: boolean(),
+    backoff :: backoff:backoff(),
+    backoff_timer :: undefined | reference()
+}).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+start_link(Args) ->
+    gen_server:start_link({local, ?SERVER}, ?SERVER, Args, []).
+
+start_ws_connection() ->
+    ?MODULE ! ?START_WS_CONNECTION.
+
+%% ------------------------------------------------------------------
+%% gen_server Function Definitions
+%% ------------------------------------------------------------------
+init(Args) ->
+    ct:print("~p init with ~p", [?SERVER, Args]),
+    lager:info("~p init with ~p", [?SERVER, Args]),
+    AutoConnect =
+        case maps:get(auto_connect, Args, false) of
+            "true" -> true;
+            true -> true;
+            _ -> false
+        end,
+    Backoff = backoff:type(backoff:init(?BACKOFF_MIN, ?BACKOFF_MAX), normal),
+    {ok,
+        #state{
+            auto_connect = AutoConnect,
+            backoff = Backoff
+        },
+        {continue, ?START_WS_CONNECTION}}.
+
+handle_continue(?START_WS_CONNECTION, #state{auto_connect = true} = State) ->
+    lager:info("auto connecting websocket"),
+    ?MODULE:start_ws_connection(),
+    {noreply, State};
+handle_continue(?START_WS_CONNECTION, #state{auto_connect = false} = State) ->
+    {noreply, State};
+handle_continue(_Msg, State) ->
+    lager:warning("rcvd unknown continue msg: ~p", [_Msg]),
+    {noreply, State}.
+
+handle_call(_Msg, _From, State) ->
+    lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    lager:debug("rcvd unknown cast msg: ~p", [_Msg]),
+    {noreply, State}.
+
+handle_info(?START_WS_CONNECTION, State0) ->
+    State1 =
+        case pp_console_ws_worker:start_ws() of
+            {ok, _} ->
+                _ = pp_console_ws_worker:activate(),
+                backoff_success(State0);
+            {error, Reason, Err} ->
+                lager:warning(
+                    "could not start websocket connection: [reason: ~p] [error: ~p]",
+                    [Reason, Err]
+                ),
+                backoff_failure(State0)
+        end,
+    {noreply, State1};
+handle_info(_Msg, State) ->
+    lager:warning("rcvd unknown info msg: ~p, ~p", [_Msg, State]),
+    {noreply, State}.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ct:print("went down ~p : ~p", [?MODULE, _Reason]),
+    ok.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+backoff_success(#state{backoff = Backoff0, backoff_timer = Timer} = State) ->
+    _ = (catch erlang:cancel_timer(Timer)),
+    {_, Backoff1} = backoff:succeed(Backoff0),
+    State#state{
+        backoff = Backoff1,
+        backoff_timer = undefined
+    }.
+
+backoff_failure(#state{backoff = Backoff0, backoff_timer = Timer} = State) ->
+    _ = (catch erlang:cancel_timer(Timer)),
+    {Delay, Backoff1} = backoff:fail(Backoff0),
+    State#state{
+        backoff = Backoff1,
+        backoff_timer = erlang:send_after(Delay, self(), ?START_WS_CONNECTION)
+    }.

--- a/src/apis/pp_console_ws_worker.erl
+++ b/src/apis/pp_console_ws_worker.erl
@@ -2,8 +2,7 @@
 %% @doc
 %% == Packet Purchaser Console WS Worker ==
 %%
-%% - Restarts websocket connection if it goes down
-%% - Handles Roaming Console messages forwarded from ws_handler
+%% - Handles Roaming Console messages forwarded from ws_client
 %% - Sending messages to Roaming Console
 %%
 %% @end

--- a/src/apis/pp_console_ws_worker.erl
+++ b/src/apis/pp_console_ws_worker.erl
@@ -36,7 +36,8 @@
 -export([
     ws_update_pid/1,
     ws_joined/0,
-    ws_handle_message/3
+    ws_handle_message/3,
+    ws_get_auto_join_topics/0
 ]).
 
 %% ------------------------------------------------------------------
@@ -92,6 +93,10 @@ ws_joined() ->
 -spec ws_handle_message(Topic :: binary(), Event :: binary(), Payload :: map()) -> ok.
 ws_handle_message(Topic, Event, Payload) ->
     gen_server:cast(?MODULE, {ws_message, Topic, Event, Payload}).
+
+-spec ws_get_auto_join_topics() -> list(binary()).
+ws_get_auto_join_topics() ->
+    [?ORGANIZATION_TOPIC, ?NET_ID_TOPIC].
 
 -spec handle_packet(
     NetID :: non_neg_integer(),

--- a/src/apis/pp_console_ws_worker.erl
+++ b/src/apis/pp_console_ws_worker.erl
@@ -117,7 +117,7 @@ handle_packet(NetID, Packet, PacketTime, Type) ->
     Topic = ?ORGANIZATION_TOPIC,
     Event = ?WS_SEND_NEW_PACKET,
 
-    Payload = pp_console_ws_handler:encode_msg(Ref, Topic, Event, Data),
+    Payload = pp_console_ws_client:encode_msg(Ref, Topic, Event, Data),
     ok = pp_metrics:ws_send_msg(NetID),
     ?MODULE:send(Payload).
 
@@ -125,7 +125,7 @@ handle_packet(NetID, Packet, PacketTime, Type) ->
 send_address() ->
     PubKeyBin = blockchain_swarm:pubkey_bin(),
     B58 = libp2p_crypto:bin_to_b58(PubKeyBin),
-    RouterAddressPayload = pp_console_ws_handler:encode_msg(
+    RouterAddressPayload = pp_console_ws_client:encode_msg(
         <<"0">>,
         ?ORGANIZATION_TOPIC,
         ?WS_SEND_PP_ADDRESS,
@@ -139,7 +139,7 @@ send_get_config() ->
     Ref = <<"0">>,
     Topic = ?ORGANIZATION_TOPIC,
     Event = ?WS_SEND_GET_CONFIG,
-    Payload = pp_console_ws_handler:encode_msg(Ref, Topic, Event, #{}),
+    Payload = pp_console_ws_client:encode_msg(Ref, Topic, Event, #{}),
     ?MODULE:send(Payload).
 
 -spec send_get_org_balances() -> ok.
@@ -148,7 +148,7 @@ send_get_org_balances() ->
     Ref = <<"0">>,
     Topic = ?ORGANIZATION_TOPIC,
     Event = ?WS_SEND_GET_ORG_BALANCES,
-    Payload = pp_console_ws_handler:encode_msg(Ref, Topic, Event, #{}),
+    Payload = pp_console_ws_client:encode_msg(Ref, Topic, Event, #{}),
     ?MODULE:send(Payload).
 
 -spec send(Data :: any()) -> ok.

--- a/src/apis/pp_console_ws_worker.erl
+++ b/src/apis/pp_console_ws_worker.erl
@@ -87,7 +87,8 @@ ws_update_pid(Pid) ->
 
 -spec ws_joined() -> ok.
 ws_joined() ->
-    ?MODULE:send_address().
+    ?MODULE:send_address(),
+    ?MODULE:send_get_config().
 
 -spec ws_handle_message(Topic :: binary(), Event :: binary(), Payload :: map()) -> ok.
 ws_handle_message(Topic, Event, Payload) ->

--- a/test/console_callback.erl
+++ b/test/console_callback.erl
@@ -81,14 +81,14 @@ handle_event(_Event, _Data, _Args) ->
     ok.
 
 websocket_handle(_Req, {text, Msg}, State) ->
-    {ok, Map} = pp_console_ws_handler:decode_msg(Msg),
+    {ok, Map} = pp_console_ws_client:decode_msg(Msg),
     handle_message(Map, State);
 websocket_handle(_Req, _Frame, State) ->
     lager:warning("websocket_handle ~p", [_Frame]),
     {ok, State}.
 
 websocket_info(_Req, {?UPDATE_CONFIG, Map}, State) ->
-    Data = pp_console_ws_handler:encode_msg(
+    Data = pp_console_ws_client:encode_msg(
         <<"0">>,
         <<"organization:all">>,
         <<"organization:all:config:list">>,
@@ -96,7 +96,7 @@ websocket_info(_Req, {?UPDATE_CONFIG, Map}, State) ->
     ),
     {reply, {text, Data}, State};
 websocket_info(_Req, {?START_BUYING, NetIDs}, State) ->
-    Data = pp_console_ws_handler:encode_msg(
+    Data = pp_console_ws_client:encode_msg(
         <<"0">>,
         <<"net_id:all">>,
         <<"net_id:all:keep_purchasing">>,
@@ -104,7 +104,7 @@ websocket_info(_Req, {?START_BUYING, NetIDs}, State) ->
     ),
     {reply, {text, Data}, State};
 websocket_info(_Req, {?STOP_BUYING, NetIDs}, State) ->
-    Data = pp_console_ws_handler:encode_msg(
+    Data = pp_console_ws_client:encode_msg(
         <<"0">>,
         <<"net_id:all">>,
         <<"net_id:all:stop_purchasing">>,
@@ -112,7 +112,7 @@ websocket_info(_Req, {?STOP_BUYING, NetIDs}, State) ->
     ),
     {reply, {text, Data}, State};
 websocket_info(_Req, ?REQUEST_ADDRESS, State) ->
-    Data = pp_console_ws_handler:encode_msg(
+    Data = pp_console_ws_client:encode_msg(
         <<"0">>,
         <<"organization:all">>,
         <<"organization:all:refetch:packet_purchaser_address">>,
@@ -147,7 +147,7 @@ handle(_Method, _Path, _Req, _Args) ->
     {404, [], <<"Not Found">>}.
 
 handle_message(#{ref := Ref, topic := <<"phoenix">>, event := <<"heartbeat">>}, State) ->
-    Data = pp_console_ws_handler:encode_msg(Ref, <<"phoenix">>, <<"phx_reply">>, #{
+    Data = pp_console_ws_client:encode_msg(Ref, <<"phoenix">>, <<"phx_reply">>, #{
         <<"status">> => <<"ok">>
     }),
     {reply, {text, Data}, State};

--- a/test/pp_sc_packet_handler_SUITE.erl
+++ b/test/pp_sc_packet_handler_SUITE.erl
@@ -89,13 +89,13 @@ all() ->
 %%--------------------------------------------------------------------
 init_per_testcase(join_websocket_inactive_test = TestCase, Config0) ->
     Config1 = [
-        {console_api, [{is_active, false}]}
+        {console_api, [{auto_connect, false}]}
         | Config0
     ],
     test_utils:init_per_testcase(TestCase, Config1);
 init_per_testcase(packet_websocket_inactive_test = TestCase, Config0) ->
     Config1 = [
-        {console_api, [{is_active, false}]}
+        {console_api, [{auto_connect, false}]}
         | Config0
     ],
     test_utils:init_per_testcase(TestCase, Config1);

--- a/test/pp_ws_SUITE.erl
+++ b/test/pp_ws_SUITE.erl
@@ -11,8 +11,6 @@
     ws_receive_packet_test/1,
     ws_console_update_config_test/1,
     ws_console_update_config_redirect_udp_worker_test/1,
-    ws_active_inactive_test/1,
-    ws_active_countdown_test/1,
     ws_stop_start_purchasing_test/1,
     ws_request_address_test/1
 ]).
@@ -42,8 +40,6 @@ all() ->
         ws_receive_packet_test,
         ws_console_update_config_test,
         ws_console_update_config_redirect_udp_worker_test,
-        ws_active_inactive_test,
-        ws_active_countdown_test,
         ws_stop_start_purchasing_test,
         ws_request_address_test
     ].
@@ -79,49 +75,6 @@ ws_receive_packet_test(_Config) ->
 
     ok = ws_send_bin(<<"packet_three">>),
     {ok, <<"packet_three">>} = test_utils:ws_test_rcv(),
-
-    ok.
-
-ws_active_inactive_test(_Config) ->
-    {ok, _} = test_utils:ws_init(),
-
-    ok = ws_send_bin(<<"should_receive">>),
-    {ok, <<"should_receive">>} = test_utils:ws_test_rcv(),
-
-    {ok, inactive} = pp_console_ws_worker:deactivate(),
-
-    ok = ws_send_bin(<<"should_not_receive">>),
-    ?assertException(
-        exit,
-        {test_case_failed, websocket_test_message_timeout},
-        test_utils:ws_test_rcv()
-    ),
-
-    {ok, active} = pp_console_ws_worker:activate(),
-
-    ok = ws_send_bin(<<"should_receive_again">>),
-    {ok, <<"should_receive_again">>} = test_utils:ws_test_rcv(),
-
-    ok.
-
-ws_active_countdown_test(_Config) ->
-    {ok, _} = test_utils:ws_init(),
-
-    %% Turn on ws for 2 messages
-    {ok, active} = pp_console_ws_worker:activate(2),
-
-    ok = ws_send_bin(<<"should_receive_1">>),
-    {ok, <<"should_receive_1">>} = test_utils:ws_test_rcv(),
-
-    ok = ws_send_bin(<<"should_receive_2">>),
-    {ok, <<"should_receive_2">>} = test_utils:ws_test_rcv(),
-
-    ok = ws_send_bin(<<"should_not_receive">>),
-    ?assertException(
-        exit,
-        {test_case_failed, websocket_test_message_timeout},
-        test_utils:ws_test_rcv()
-    ),
 
     ok.
 

--- a/test/pp_ws_SUITE.erl
+++ b/test/pp_ws_SUITE.erl
@@ -80,16 +80,18 @@ ws_receive_packet_test(_Config) ->
 
 ws_request_address_test(_Config) ->
     {ok, WSPid} = test_utils:ws_init(),
-    {ok, active} = pp_console_ws_worker:activate(),
 
     PubKeyBin = blockchain_swarm:pubkey_bin(),
     B58 = libp2p_crypto:bin_to_b58(PubKeyBin),
 
     console_callback:request_address(WSPid),
-    {ok, #{
-        event := <<"packet_purchaser:address">>,
-        payload := #{<<"address">> := B58}
-    }} = test_utils:ws_roaming_rcv(),
+    ?assertMatch(
+        {ok, #{
+            event := <<"packet_purchaser:address">>,
+            payload := #{<<"address">> := B58}
+        }},
+        test_utils:ws_roaming_rcv(pp_request_address)
+    ),
 
     ok.
 

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -209,7 +209,7 @@ wait_until(Fun, Retry, Delay) when Retry > 0 ->
 
 -spec ws_prepare_test_msg(binary()) -> ok.
 ws_prepare_test_msg(Bin) ->
-    pp_console_ws_handler:encode_msg(<<"0">>, <<"test_utils">>, <<"test_message">>, Bin).
+    pp_console_ws_client:encode_msg(<<"0">>, <<"test_utils">>, <<"test_message">>, Bin).
 
 -spec ws_test_rcv() -> {ok, any()}.
 ws_test_rcv() ->

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -43,7 +43,7 @@ init_per_testcase(TestCase, Config) ->
         {endpoint, ?CONSOLE_URL},
         {ws_endpoint, ?CONSOLE_WS_URL},
         {secret, <<>>},
-        {is_active, true}
+        {auto_connect, true}
     ],
     OverrideConsoleSettings = proplists:get_value(console_api, Config, []),
     ok = application:set_env(

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -21,7 +21,7 @@
     %%
     ws_rcv/0,
     ws_init/0,
-    ws_roaming_rcv/0,
+    ws_roaming_rcv/1,
     ws_test_rcv/0,
     ws_prepare_test_msg/1,
     %%
@@ -232,10 +232,10 @@ ws_init() ->
         after 2500 -> ct:fail(websocket_init_timeout)
         end,
     %% Eat phx_join message and packet_purchaser address message
-    {ok, #{event := <<"phx_join">>, topic := <<"organization:all">>}} = ws_roaming_rcv(),
-    {ok, #{event := <<"phx_join">>, topic := <<"net_id:all">>}} = ws_roaming_rcv(),
-    {ok, #{event := <<"packet_purchaser:address">>}} = ws_roaming_rcv(),
-    {ok, #{event := <<"packet_purchaser:get_config">>}} = ws_roaming_rcv(),
+    {ok, #{event := <<"phx_join">>, topic := <<"organization:all">>}} = ws_roaming_rcv(org_join),
+    {ok, #{event := <<"phx_join">>, topic := <<"net_id:all">>}} = ws_roaming_rcv(net_id_join),
+    {ok, #{event := <<"packet_purchaser:address">>}} = ws_roaming_rcv(pp_address),
+    {ok, #{event := <<"packet_purchaser:get_config">>}} = ws_roaming_rcv(pp_get_config),
     R.
 
 -spec ws_rcv() -> {ok, any()}.
@@ -247,12 +247,12 @@ ws_rcv() ->
     after 2500 -> ct:fail(websocket_msg_timeout)
     end.
 
--spec ws_roaming_rcv() -> {ok, binary(), binary(), any()}.
-ws_roaming_rcv() ->
+-spec ws_roaming_rcv(atom()) -> {ok, binary(), binary(), any()}.
+ws_roaming_rcv(ErrId) ->
     receive
         {websocket_msg, Payload} ->
             {ok, Payload}
-    after 2500 -> ct:fail(websocket_roaming_msg_timeout)
+    after 2500 -> ct:fail({websocket_roaming_msg_timeout, ErrId})
     end.
 
 ignore_messages() ->


### PR DESCRIPTION
The ws_worker starts up without trying to connect. 
There's a new ws_monitor that will tell ws_worker to start the connection on startup. 
This lets the ws connection fail without continually bringing down the service.