### PR TITLE
Update config from Websocket

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -16,6 +16,7 @@
             {secret, <<>>},
             {is_active, false}
         ]},
+        {update_from_ws_config, false},
         {sc_open_dc_amount, 100},
         {sc_expiration_interval, 25},
         {sc_expiration_buffer, 15},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -19,6 +19,7 @@
             {secret, <<"${PP_CONSOLE_SECRET}">>},
             {is_active, "${PP_ENABLE_CONSOLE}"}
         ]},
+        {update_from_ws_config, false},
         {sc_open_dc_amount, "${PP_SC_OPEN_DC_AMOUNT}"},
         {sc_expiration_interval, "${PP_SC_EXPIRATION_INTERVAL}"},
         {sc_expiration_buffer, "${PP_SC_EXPIRATION_BUFFER}"},

--- a/config/test.config
+++ b/config/test.config
@@ -14,6 +14,7 @@
             {api_key, "XXX"},
             {app_eui, "0000000000000000"}
         ]},
+        {update_from_ws_config, true},
         {sc_open_dc_amount, 100},
         {sc_expiration_interval, 25},
         {pp_routing_config_filename, testing}

--- a/src/apis/pp_console_ws_worker.erl
+++ b/src/apis/pp_console_ws_worker.erl
@@ -251,9 +251,20 @@ terminate(_Reason, _State) ->
 %% ------------------------------------------------------------------
 %% Receive Message handler functions
 %% ------------------------------------------------------------------
-handle_message(?ORGANIZATION_TOPIC, ?WS_RCV_CONFIG_LIST, Payload) ->
+handle_message(
+    ?ORGANIZATION_TOPIC,
+    ?WS_RCV_CONFIG_LIST,
+    #{<<"org_config_list">> := Config} = Payload
+) ->
     lager:info("updating config: ~p", [Payload]),
-    ok = pp_config:ws_update_config(Payload);
+    try pp_config:transform_config(Config) of
+        _ -> lager:info("valid config")
+    catch
+        Class:Err -> lager:error("could not parse config [error: ~p]", [{Class, Err}])
+    end,
+    %% NOTE: not updating from console config yet
+    %% ok = pp_config:ws_update_config(Config),
+    ok;
 handle_message(?ORGANIZATION_TOPIC, ?WS_RCV_DC_BALANCE_LIST, Payload) ->
     lager:info("updating dc balances: ~p", [Payload]),
     ok;

--- a/src/apis/pp_console_ws_worker.erl
+++ b/src/apis/pp_console_ws_worker.erl
@@ -256,14 +256,29 @@ handle_message(
     ?WS_RCV_CONFIG_LIST,
     #{<<"org_config_list">> := Config} = Payload
 ) ->
-    lager:info("updating config: ~p", [Payload]),
-    try pp_config:transform_config(Config) of
-        _ -> lager:info("valid config")
-    catch
-        Class:Err -> lager:error("could not parse config [error: ~p]", [{Class, Err}])
+    UpdateFromWsConfig =
+        case application:get_env(packet_purchaser, update_from_ws_config, false) of
+            "true" -> true;
+            true -> true;
+            _ -> false
+        end,
+    lager:info("updating config: [updating: ~p] [payload: ~p]", [UpdateFromWsConfig, Payload]),
+    ConfigParseable =
+        try pp_config:transform_config(Config) of
+            _ ->
+                lager:info("valid config"),
+                true
+        catch
+            Class:Err ->
+                lager:error("could not parse config [error: ~p]", [{Class, Err}]),
+                false
+        end,
+    case UpdateFromWsConfig andalso ConfigParseable of
+        true ->
+            pp_config:ws_update_config(Config);
+        _ ->
+            ok
     end,
-    %% NOTE: not updating from console config yet
-    %% ok = pp_config:ws_update_config(Config),
     ok;
 handle_message(?ORGANIZATION_TOPIC, ?WS_RCV_DC_BALANCE_LIST, Payload) ->
     lager:info("updating dc balances: ~p", [Payload]),

--- a/src/pp_config.erl
+++ b/src/pp_config.erl
@@ -178,8 +178,9 @@ reset_config() ->
 -spec load_config(list(map())) -> ok.
 load_config(ConfigList) ->
     {ok, PrevConfig} = ?MODULE:get_config(),
-    ok = ?MODULE:reset_config(),
     Config = ?MODULE:transform_config(ConfigList),
+
+    ok = ?MODULE:reset_config(),
     ok = ?MODULE:write_config_to_ets(Config),
 
     #{routing := PrevRouting} = PrevConfig,

--- a/test/console_callback.erl
+++ b/test/console_callback.erl
@@ -30,7 +30,7 @@
 
 -spec update_config(pid(), list(map())) -> ok.
 update_config(WSPid, Config) ->
-    WSPid ! {?UPDATE_CONFIG, Config},
+    WSPid ! {?UPDATE_CONFIG, #{<<"org_config_list">> => Config}},
     ok.
 
 -spec start_buying(pid(), list(integer())) -> ok.

--- a/test/pp_ws_SUITE.erl
+++ b/test/pp_ws_SUITE.erl
@@ -141,6 +141,8 @@ ws_request_address_test(_Config) ->
     ok.
 
 ws_console_update_config_test(_Config) ->
+    %% NOTE: true is the default in test.config. This is for communication purposes.
+    ok = application:set_env(packet_purchaser, update_from_ws_config, true),
     {ok, WSPid} = test_utils:ws_init(),
     OneMapped = [
         #{
@@ -198,6 +200,24 @@ ws_console_update_config_test(_Config) ->
         {ok, pp_config:transform_config(TwoReMapped)},
         pp_config:get_config()
     ),
+
+    %% Now we turn off taking config updates from ws
+    ok = application:set_env(packet_purchaser, update_from_ws_config, false),
+    ok = pp_config:reset_config(),
+
+    Empty = #{joins => [], routing => []},
+
+    console_callback:update_config(WSPid, OneMapped),
+    timer:sleep(500),
+    ?assertEqual({ok, Empty}, pp_config:get_config()),
+
+    console_callback:update_config(WSPid, TwoMapped),
+    timer:sleep(500),
+    ?assertEqual({ok, Empty}, pp_config:get_config()),
+
+    console_callback:update_config(WSPid, TwoReMapped),
+    timer:sleep(500),
+    ?assertEqual({ok, Empty}, pp_config:get_config()),
 
     ok.
 


### PR DESCRIPTION
The current payload coming from roaming-console to update the config had changed without a matching update.

Until something smarter is in place, there's an option to ignore incoming configurations (but still attempt to parse them).