### PR TITLE
Move init_ets to supervisor

### DIFF
--- a/src/pp_config.erl
+++ b/src/pp_config.erl
@@ -268,10 +268,8 @@ stop_buying([NetID | NetIDS]) ->
 %% -------------------------------------------------------------------
 
 init([testing]) ->
-    ok = ?MODULE:init_ets(),
     {ok, #state{filename = testing}};
 init([Filename]) ->
-    ok = ?MODULE:init_ets(),
     Config0 = ?MODULE:read_config(Filename),
     Config1 = ?MODULE:transform_config(Config0),
     ok = ?MODULE:write_config_to_ets(Config1),
@@ -445,6 +443,7 @@ clean_config_value(Bin) -> Bin.
 -include_lib("eunit/include/eunit.hrl").
 
 join_eui_to_net_id_test() ->
+    ok = pp_config:init_ets(),
     {ok, _} = pp_config:start_link(testing),
     Dev1 = 7,
     App1 = 13,

--- a/src/pp_sup.erl
+++ b/src/pp_sup.erl
@@ -71,14 +71,17 @@ init([]) ->
 
     {ok, ConfigFilename} = application:get_env(packet_purchaser, pp_routing_config_filename),
 
+    ok = pp_multi_buy:init_ets(),
+    ok = pp_config:init_ets(),
+
     ChildSpecs = [
-        ?SUP(blockchain_sup, [BlockchainOpts]),
+        ?WORKER(pp_multi_buy, []),
         ?WORKER(pp_config, [ConfigFilename]),
+        ?SUP(blockchain_sup, [BlockchainOpts]),
         ?WORKER(pp_sc_worker, [#{}]),
         ?SUP(pp_udp_sup, []),
         ?SUP(pp_console_sup, []),
-        ?WORKER(pp_metrics, []),
-        ?WORKER(pp_multi_buy, [])
+        ?WORKER(pp_metrics, [])
     ],
     {ok, {?FLAGS, ChildSpecs}}.
 


### PR DESCRIPTION
We were starting up the blockchain first. But it could get going quick
enough that packets were failing to be handled because the rest of the
machinery was still coming up and not all the ets tables existed.