### PR TITLE
stop double reporting metrics

### DIFF
--- a/src/pp_metrics.erl
+++ b/src/pp_metrics.erl
@@ -169,7 +169,6 @@ init(Args) ->
 
     ok = init_ets(),
     ok = declare_metrics(),
-    _ = schedule_next_tick(),
 
     _ = erlang:send_after(500, self(), post_init),
 


### PR DESCRIPTION
most of the metrics require the chain, and if we can't get it here, we
have some problems, and 0s in the metrics will alarm.