### PR TITLE
env vars normally come through as strings

### DIFF
--- a/src/apis/pp_console_ws_manager.erl
+++ b/src/apis/pp_console_ws_manager.erl
@@ -82,10 +82,15 @@ init(Args) ->
         ws_endpoint = WSEndpoint,
         backoff = Backoff
     },
-    case maps:get(auto_connect, Args, false) of
+    AutoConnect =
+        case maps:get(auto_connect, Args, false) of
+            "true" -> true;
+            V -> V
+        end,
+    case AutoConnect of
         true ->
             {ok, State, {continue, ?GET_TOKEN}};
-        false ->
+        _ ->
             {ok, State}
     end.
 

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -43,7 +43,7 @@ init_per_testcase(TestCase, Config) ->
         {endpoint, ?CONSOLE_URL},
         {ws_endpoint, ?CONSOLE_WS_URL},
         {secret, <<>>},
-        {auto_connect, true}
+        {auto_connect, "true"}
     ],
     OverrideConsoleSettings = proplists:get_value(console_api, Config, []),
     ok = application:set_env(


### PR DESCRIPTION
Even for bools, we have to treat them into the atoms they wnat to be in
the world. At some point we might want to revamp the env var
substitution to go directly to the datatype we're expecting.