### PR TITLE
bring over and remove device specific multi-buy functionality

### DIFF
--- a/src/pp_config.erl
+++ b/src/pp_config.erl
@@ -386,6 +386,7 @@ transform_config_entry(Entry) ->
     MultiBuy =
         case maps:get(<<"multi_buy">>, Entry, null) of
             null -> unlimited;
+            <<"unlimited">> -> unlimited;
             Val -> Val
         end,
     Joins = maps:get(<<"joins">>, Entry, []),

--- a/src/pp_multi_buy.erl
+++ b/src/pp_multi_buy.erl
@@ -1,68 +1,36 @@
 %%%-------------------------------------------------------------------
 %% @doc
 %% == Packet Purchaser Multi Buy ==
-%% @end
-%%%-------------------------------------------------------------------
+%%
+%% The first time a PHash is encountered it's inserted into the MB ets table
+%% along with the time of the first purchase.
+%%
+%% Subsequent purchases will increment the number bought until we reach the
+%% threshold and wrap around to a very low number.
+%%
+%% As long as the number bought is less than `0' no more will be purchased.
+%%
+%% A scheduled cleanup comes around and looks for all objects where the Time
+%% position is far enough in the past to be deleted.
+%%
+%% @end %-------------------------------------------------------------------
 -module(pp_multi_buy).
-
--behaviour(gen_server).
--include("packet_purchaser.hrl").
-
-%% gen_server API
--export([start_link/0]).
 
 %% Multi-buy API
 -export([
     maybe_buy_offer/2,
-    init_ets/0
+    init/0,
+    cleanup/1
 ]).
 
-%% gen_server callbacks
--export([
-    init/1,
-    handle_call/3,
-    handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
-]).
-
-%% Multi Buy
 -define(MB_ETS, multi_buy_ets).
--define(MB_UNLIMITED, 9999).
+-define(MB_MAX_BUY_RESET_VALUE, -9999).
 -define(MB_MAX_PACKET, multi_buy_max_packet).
 -define(MB_BUYING_DISABLED, multi_buy_disabled).
--define(MB_EVICT_TIMEOUT, timer:seconds(6)).
--define(MB_FUN(Hash), [
-    {
-        {Hash, '$1', '$2'},
-        [{'=<', '$2', '$1'}],
-        [{{Hash, '$1', {'+', '$2', 1}}}]
-    }
-]).
+-define(MB_CLEANUP, timer:minutes(30)).
 
--define(BF_ETS, pp_device_routing_bf_ets).
--define(BF_KEY, bloom_key).
-%% https://hur.st/bloomfilter/?n=10000&p=1.0E-6&m=&k=20
--define(BF_UNIQ_CLIENTS_MAX, 10000).
-%% -define(BF_FALSE_POS_RATE, 1.0e-6).
--define(BF_BITMAP_SIZE, 300000).
--define(BF_FILTERS_MAX, 14).
--define(BF_ROTATE_AFTER, 1000).
-
--define(NET_ID_NOT_CONFIGURED, net_id_not_configured).
-
--record(state, {}).
-
-%% -------------------------------------------------------------------
-%% API Functions
-%% -------------------------------------------------------------------
-
-start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
-
--spec init_ets() -> ok.
-init_ets() ->
+-spec init() -> ok.
+init() ->
     ?MB_ETS = ets:new(?MB_ETS, [
         public,
         named_table,
@@ -70,14 +38,7 @@ init_ets() ->
         {write_concurrency, true},
         {read_concurrency, true}
     ]),
-    ets:new(?BF_ETS, [public, named_table, set, {read_concurrency, true}]),
-    {ok, BloomJoinRef} = bloom:new_forgetful(
-        ?BF_BITMAP_SIZE,
-        ?BF_UNIQ_CLIENTS_MAX,
-        ?BF_FILTERS_MAX,
-        ?BF_ROTATE_AFTER
-    ),
-    true = ets:insert(?BF_ETS, {?BF_KEY, BloomJoinRef}),
+    ok = scheduled_cleanup(?MB_CLEANUP),
     ok.
 
 -spec maybe_buy_offer(
@@ -86,81 +47,47 @@ init_ets() ->
 ) -> ok | {error, any()}.
 maybe_buy_offer(_Offer, 0) ->
     {error, ?MB_BUYING_DISABLED};
+maybe_buy_offer(_Offer, unlimited) ->
+    ok;
 maybe_buy_offer(Offer, MultiBuyMax) ->
     PHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
-    BFRef = lookup_bf(?BF_KEY),
-    case bloom:set(BFRef, PHash) of
-        false ->
-            maybe_buy_offer_unseen_hash(MultiBuyMax, PHash);
-        true ->
-            case ets:lookup(?MB_ETS, PHash) of
-                [] ->
-                    maybe_buy_offer_unseen_hash(MultiBuyMax, PHash);
-                [{PHash, Max, Max}] ->
-                    {error, ?MB_MAX_PACKET};
-                [{PHash, _Max, _Curr}] ->
-                    case ets:select_replace(?MB_ETS, ?MB_FUN(PHash)) of
-                        0 -> {error, ?MB_MAX_PACKET};
-                        1 -> ok
-                    end
-            end
+
+    case
+        ets:update_counter(
+            ?MB_ETS,
+            PHash,
+            {2, 1, MultiBuyMax, ?MB_MAX_BUY_RESET_VALUE},
+            {default, 0, erlang:system_time(millisecond)}
+        )
+    of
+        Count when Count =< 0 -> {error, ?MB_MAX_PACKET};
+        _Count -> ok
     end.
 
--spec maybe_buy_offer_unseen_hash(
-    MultiBuyMax :: unlimited | non_neg_integer(),
-    PacketHash :: binary()
-) -> ok | {error, any()}.
-maybe_buy_offer_unseen_hash(unlimited, _PHash) ->
-    ok;
-maybe_buy_offer_unseen_hash(MultiBuyMax, PHash) ->
-    ok = schedule_clear_multi_buy(PHash),
-    true = ets:insert(?MB_ETS, {PHash, MultiBuyMax, 1}),
+-spec scheduled_cleanup(Duration :: non_neg_integer()) -> ok.
+scheduled_cleanup(Duration) ->
+    erlang:spawn(
+        fun() ->
+            ok = cleanup(Duration),
+            timer:sleep(Duration),
+            ok = scheduled_cleanup(Duration)
+        end
+    ),
     ok.
 
-%% -------------------------------------------------------------------
-%% gen_server Callbacks
-%% -------------------------------------------------------------------
-
-init([]) ->
-    {ok, #state{}}.
-
-handle_call(_Request, _From, State) ->
-    {reply, ignored, State}.
-
-handle_cast(_Msg, State) ->
-    {noreply, State}.
-
-handle_info({multi_buy_evict, PHash}, State) ->
-    true = ets:delete(?MB_ETS, PHash),
-    lager:debug("cleared multi buy for ~p", [PHash]),
-    {noreply, State};
-handle_info(_Info, State) ->
-    {noreply, State}.
-
-terminate(_Reason, _State) ->
+cleanup(Duration) ->
+    Time = erlang:system_time(millisecond) - Duration,
+    Expired = select_expired(Time),
+    lists:foreach(fun(PHash) -> ets:delete(?MB_ETS, PHash) end, Expired),
+    lager:debug("expiring ~p PHash", [erlang:length(Expired)]),
     ok.
 
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
-
-%% ------------------------------------------------------------------
-%% Internal Function Definitions
-%% ------------------------------------------------------------------
-
--spec lookup_bf(atom()) -> reference().
-lookup_bf(Key) ->
-    [{Key, Ref}] = ets:lookup(?BF_ETS, Key),
-    Ref.
-
--spec schedule_clear_multi_buy(binary()) -> ok.
-schedule_clear_multi_buy(PHash) ->
-    _TRef = erlang:send_after(multi_buy_eviction_timeout(), ?MODULE, {multi_buy_evict, PHash}),
-    ok.
-
--spec multi_buy_eviction_timeout() -> non_neg_integer().
-multi_buy_eviction_timeout() ->
-    case application:get_env(?APP, multi_buy_eviction_timeout, ?MB_EVICT_TIMEOUT) of
-        [] -> ?MB_EVICT_TIMEOUT;
-        Str when is_list(Str) -> erlang:list_to_integer(Str);
-        I -> I
-    end.
+-spec select_expired(Time :: non_neg_integer()) -> list(binary()).
+select_expired(Time) ->
+    ets:select(?MB_ETS, [
+        {
+            {'$1', '$2', '$3'},
+            [{'<', '$3', Time}],
+            ['$1']
+        }
+    ]).

--- a/src/pp_multi_buy.erl
+++ b/src/pp_multi_buy.erl
@@ -31,6 +31,12 @@
 
 -spec init() -> ok.
 init() ->
+    ok = init_ets(),
+    ok = scheduled_cleanup(?MB_CLEANUP),
+    ok.
+
+-spec init_ets() -> ok.
+init_ets() ->
     ?MB_ETS = ets:new(?MB_ETS, [
         public,
         named_table,
@@ -38,20 +44,25 @@ init() ->
         {write_concurrency, true},
         {read_concurrency, true}
     ]),
-    ok = scheduled_cleanup(?MB_CLEANUP),
     ok.
 
 -spec maybe_buy_offer(
     Offer :: blockchain_state_channel_offer_v1:offer(),
     MultiBuyMax :: unlimited | non_neg_integer()
 ) -> ok | {error, any()}.
-maybe_buy_offer(_Offer, 0) ->
-    {error, ?MB_BUYING_DISABLED};
-maybe_buy_offer(_Offer, unlimited) ->
-    ok;
 maybe_buy_offer(Offer, MultiBuyMax) ->
     PHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
+    maybe_buy(PHash, MultiBuyMax).
 
+-spec maybe_buy(
+    PHash :: binary(),
+    MultiBuyMax :: unlimited | non_neg_integer()
+) -> ok | {error, any()}.
+maybe_buy(_Offer, 0) ->
+    {error, ?MB_BUYING_DISABLED};
+maybe_buy(_Offer, unlimited) ->
+    ok;
+maybe_buy(PHash, MultiBuyMax) ->
     case
         ets:update_counter(
             ?MB_ETS,
@@ -91,3 +102,188 @@ select_expired(Time) ->
             ['$1']
         }
     ]).
+
+%%====================================================================
+%% Tests
+%%====================================================================o
+
+-ifdef(TEST).
+
+-define(TEST_SLEEP, 250).
+-define(TEST_PERF, 1000).
+
+-include_lib("eunit/include/eunit.hrl").
+
+multi_buy_test_() ->
+    {
+        foreach,
+        fun() -> ok = init_ets() end,
+        fun(_) -> _ = catch ets:delete(?MB_ETS) end,
+        [
+            fun test_maybe_buy/0,
+            fun test_maybe_buy_only_1/0,
+            fun test_maybe_buy_deny_more/0,
+            fun test_cleanup_phash/0
+        ]
+    }.
+
+test_maybe_buy() ->
+    %% Setup Max packet for device
+    Max = 5,
+
+    Parent = self(),
+    %% Setup phash and number of packet to be sent
+    PHash = crypto:strong_rand_bytes(32),
+    Packets = 100,
+    lists:foreach(
+        fun(X) ->
+            %% Each "packet sending" is spawn and sleep for a random timer defined by
+            %% ?TEST_SLEEP it will then attempt to buy and send back its result to Parent
+            erlang:spawn(
+                fun() ->
+                    timer:sleep(rand:uniform(?TEST_SLEEP)),
+                    {Time, Result} = timer:tc(fun() -> maybe_buy(PHash, Max) end),
+                    Parent ! {maybe_buy_test, X, Time, Result}
+                end
+            )
+        end,
+        lists:seq(1, Packets)
+    ),
+    %% Aggregate results
+    Results = maybe_buy_test_rcv_loop(#{}),
+    %% Filter result to only find OKs and make sure we only have MAX OKs
+    OK = maps:filter(fun(_K, {_, V}) -> V =:= ok end, Results),
+    ?assertEqual(Max, maps:size(OK)),
+    %% Filter result to only find Errors and make sure we have Packets-MAX Errors
+    Errors = maps:filter(
+        fun(_K, {_, V}) -> V =:= {error, ?MB_MAX_PACKET} end,
+        Results
+    ),
+    ?assertEqual(Packets - Max, maps:size(Errors)),
+    %% At this point a time marker should have been set in the table with that PHash
+    ?assertMatch([{PHash, _, _}], ets:lookup(?MB_ETS, PHash)),
+    %% performance check in MICRO seconds
+    TotalTime = lists:sum([T || {T, _} <- maps:values(Results)]),
+    ?assert(TotalTime / Packets < ?TEST_PERF),
+    ok.
+
+test_maybe_buy_only_1() ->
+    %% Setup Max packet for device
+    Max = 1,
+
+    Parent = self(),
+    %% Setup phash and number of packet to be sent
+    PHash = crypto:strong_rand_bytes(32),
+    Packets = 100,
+    lists:foreach(
+        fun(X) ->
+            %% Each "packet sending" is spawn and sleep for a random timer defined by
+            %% ?TEST_SLEEP it will then attempt to buy and send back its result to Parent
+            erlang:spawn(
+                fun() ->
+                    timer:sleep(rand:uniform(?TEST_SLEEP)),
+                    {Time, Result} = timer:tc(fun() -> maybe_buy(PHash, Max) end),
+                    Parent ! {maybe_buy_test, X, Time, Result}
+                end
+            )
+        end,
+        lists:seq(1, Packets)
+    ),
+    %% Aggregate results
+    Results = maybe_buy_test_rcv_loop(#{}),
+    %% Filter result to only find OKs and make sure we only have MAX OKs
+    OK = maps:filter(fun(_K, {_, V}) -> V =:= ok end, Results),
+    ?assertEqual(Max, maps:size(OK)),
+    %% Filter result to only find Errors and make sure we have Packets-MAX Errors
+    Errors = maps:filter(
+        fun(_K, {_, V}) -> V =:= {error, ?MB_MAX_PACKET} end,
+        Results
+    ),
+    ?assertEqual(Packets - Max, maps:size(Errors)),
+    %% At this point a time marker should have been set in the table with that PHash
+    ?assertMatch([{PHash, _, _}], ets:lookup(?MB_ETS, PHash)),
+    %% performance check in MICRO seconds
+    TotalTime = lists:sum([T || {T, _} <- maps:values(Results)]),
+    ?assert(TotalTime / Packets < ?TEST_PERF),
+
+    ok.
+
+test_maybe_buy_deny_more() ->
+    %% Setup Max packet for device
+    Max = 0,
+
+    Parent = self(),
+    %% Setup phash and number of packet to be sent
+    PHash = crypto:strong_rand_bytes(32),
+    Packets = 100,
+    lists:foreach(
+        fun(X) ->
+            %% Each "packet sending" is spawn and sleep for a random timer defined by
+            %% ?TEST_SLEEP it will then attempt to buy and send back its result to Parent
+            erlang:spawn(
+                fun() ->
+                    timer:sleep(rand:uniform(?TEST_SLEEP)),
+                    {Time, Result} = timer:tc(fun() -> maybe_buy(PHash, Max) end),
+                    Parent ! {maybe_buy_test, X, Time, Result}
+                end
+            )
+        end,
+        lists:seq(1, Packets)
+    ),
+    timer:sleep(50),
+    %% Aggregate results
+    Results = maybe_buy_test_rcv_loop(#{}),
+    %% Filter result to only find OKs and make sure we only have MAX OKs
+    OK = maps:filter(fun(_K, {_, V}) -> V =:= ok end, Results),
+    ?assertEqual(0, maps:size(OK)),
+    %% Filter result to only find Errors and make sure we have Packets-MAX Errors
+    Errors = maps:filter(
+        fun(_K, {_, V}) -> V =:= {error, ?MB_BUYING_DISABLED} end,
+        Results
+    ),
+    ?assertEqual(Packets, maps:size(Errors)),
+    %% At this point a time marker should have been set in the table with that PHash
+    ?assertMatch([], ets:lookup(?MB_ETS, PHash)),
+    %% performance check in MICRO seconds
+    TotalTime = lists:sum([T || {T, _} <- maps:values(Results)]),
+    ?assert(TotalTime / Packets < ?TEST_PERF),
+
+    ok.
+
+test_cleanup_phash() ->
+    %% Setup Max packet for device
+    Max = 5,
+    Packets = 100,
+    lists:foreach(
+        fun(_Idx) ->
+            %% Populate table with a bunch of different packets and max values
+            erlang:spawn(
+                fun() ->
+                    PHash = crypto:strong_rand_bytes(32),
+                    ok = maybe_buy(PHash, Max)
+                end
+            )
+        end,
+        lists:seq(1, Packets)
+    ),
+
+    %% Wait 100ms and then run a cleanup for 10ms
+    timer:sleep(100),
+    Time = erlang:system_time(millisecond) - 10,
+    ?assertEqual(Packets, erlang:length(select_expired(Time))),
+    ok = cleanup(10),
+    timer:sleep(100),
+    % %% It should remove every values except the device max
+    ?assertEqual(0, erlang:length(select_expired(Time))),
+    ?assertEqual(0, ets:info(?MB_ETS, size)),
+
+    ok.
+
+maybe_buy_test_rcv_loop(Acc) ->
+    receive
+        {maybe_buy_test, X, Time, Result} ->
+            maybe_buy_test_rcv_loop(maps:put(X, {Time, Result}, Acc))
+    after ?TEST_SLEEP -> Acc
+    end.
+
+-endif.

--- a/src/pp_multi_buy.erl
+++ b/src/pp_multi_buy.erl
@@ -67,11 +67,11 @@ maybe_buy(PHash, MultiBuyMax) ->
         ets:update_counter(
             ?MB_ETS,
             PHash,
-            {2, 1, MultiBuyMax, ?MB_MAX_BUY_RESET_VALUE},
+            {2, 1},
             {default, 0, erlang:system_time(millisecond)}
         )
     of
-        Count when Count =< 0 -> {error, ?MB_MAX_PACKET};
+        Count when Count > MultiBuyMax -> {error, ?MB_MAX_PACKET};
         _Count -> ok
     end.
 

--- a/src/pp_sup.erl
+++ b/src/pp_sup.erl
@@ -71,11 +71,10 @@ init([]) ->
 
     {ok, ConfigFilename} = application:get_env(packet_purchaser, pp_routing_config_filename),
 
-    ok = pp_multi_buy:init_ets(),
+    ok = pp_multi_buy:init(),
     ok = pp_config:init_ets(),
 
     ChildSpecs = [
-        ?WORKER(pp_multi_buy, []),
         ?WORKER(pp_config, [ConfigFilename]),
         ?SUP(blockchain_sup, [BlockchainOpts]),
         ?WORKER(pp_sc_worker, [#{}]),

--- a/test/pp_sc_packet_handler_SUITE.erl
+++ b/test/pp_sc_packet_handler_SUITE.erl
@@ -369,7 +369,6 @@ multi_buy_eviction_test(_Config) ->
             ]
         }
     ]),
-    application:set_env(packet_purchaser, multi_buy_eviction_timeout, Timeout),
 
     ErrMaxPacket = {error, multi_buy_max_packet},
     lists:foreach(
@@ -382,6 +381,8 @@ multi_buy_eviction_test(_Config) ->
 
             %% Wait out the eviction, we're attempting a replay
             timer:sleep(round(Timeout * 1.3)),
+            %% MB does bulk cleanup on large intervals, manually trigger
+            ok = pp_multi_buy:cleanup(Timeout),
             ?assertMatch(ok, pp_sc_packet_handler:handle_offer(Offer, self())),
             ?assertMatch(ErrMaxPacket, pp_sc_packet_handler:handle_offer(Offer, self())),
             ?assertMatch(ErrMaxPacket, pp_sc_packet_handler:handle_offer(Offer, self()))


### PR DESCRIPTION
There are some multi buy tests already in the sc_packet_handler_SUITE.
But it would be nice to have the same type of eunit tests from router for this.