### PR TITLE
add more metadata for tracing purposes

### DIFF
--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -96,8 +96,7 @@
         ]},
         {traces, [
             {{lager_file_backend, "packet_purchaser.log"}, [{application, packet_purchaser}], info},
-            {{lager_file_backend, "packet_purchaser.log"}, [{module, pp_sc_packet_handler}], info},
-            {{lager_file_backend, "downlink.log"}, [{module, pp_http}], debug}
+            {{lager_file_backend, "packet_purchaser.log"}, [{module, pp_sc_packet_handler}], info}
         ]}
     ]}
 ].


### PR DESCRIPTION
Adding more metadata to log lines to be able to target traces without making giant log files.

example:
```packet_purchaser trace start offer_type=join net_id=0 action=rejected```