### PR TITLE
Cache PLT during `tests` workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,6 +108,21 @@ jobs:
         run: |
           mkdir _build
           tar -xvf build.tar.gz -C _build
+      - name: set-lockfile-hash
+        id: set_vars
+        run: |
+          rebar_hash="${{hashFiles(format('{0}{1}', github.workspace, '/rebar.lock'))}}"
+          echo "::set-output name=rebar_hash::$rebar_hash"
+      - name: cache PLT files
+        id: cache-plt
+        uses: actions/cache@v2
+        with:
+          path: |
+            _build/default/*_plt
+            _build/default/*_plt.hash
+          key: plt-cache-${{ steps.set_vars.outputs.rebar_hash }}
+          restore-keys: |
+            plt-cache-
       - name: dialyzer
         run: ./rebar3 dialyzer
   ct:


### PR DESCRIPTION
This PR adds logic to the `tests` workflow to cache PLT files.  It works like this:

For each build, a hash is computed over the `rebar.lock` file.  This hash is used as a cache key.  If this key exists in the  cache, it is expected to point to a tarball containing `_build/default/*_plt`; the tarball is extracted and its contents are used as the base PLT for dialyzer.  If no entry exists in the cache, dialyzer will build the PLT in the usual way (perhaps taking a long, long time).  When the run is complete, the generated PLT will be inserted into the cache under the cache key and used for subsequent builds.