### PR TITLE
Track unique packet

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -17,7 +17,11 @@
         {http_roaming_port, 8081},
         {force_net_id_protocol_version, #{
             16#600013 => pv_1_0
-        }}
+        }},
+        {metrics, [
+            {unique_offers_cleanup_timer, 10},
+            {unique_offers_window, 180}
+        ]}
     ]},
     {blockchain, [
         {port, 2154},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -16,7 +16,10 @@
         {sc_expiration_interval, "${PP_SC_EXPIRATION_INTERVAL}"},
         {sc_expiration_buffer, "${PP_SC_EXPIRATION_BUFFER}"},
         {pp_routing_config_filename, "${PP_BASE_DIR}/${PP_ROUTING_CONFIG_FILE}"},
-        {metrics, [{record_queue_min_length, 50}]},
+        {metrics, [
+            {unique_offers_cleanup_timer, 10},
+            {unique_offers_window, 180}
+        ]},
         {http_roaming_port, "${PP_HTTP_DOWNLINK_PORT}"},
         {force_net_id_protocol_version, #{
             16#600013 => pv_1_0

--- a/src/pp_sup.erl
+++ b/src/pp_sup.erl
@@ -73,11 +73,14 @@ init([]) ->
     ok = pp_config:init_ets(),
     ok = pp_roaming_downlink:init_ets(),
     ok = pp_utils:init_ets(),
+    ok = pp_metrics:init_ets(),
 
     ElliConfig = [
         {callback, pp_roaming_downlink},
         {port, pp_utils:get_env_int(http_roaming_port, 8081)}
     ],
+
+    MetricsConfig = application:get_env(packet_purchaser, metrics, []),
 
     ChildSpecs = [
         ?WORKER(pp_config, [ConfigFilename]),
@@ -86,7 +89,7 @@ init([]) ->
         ?SUP(pp_udp_sup, []),
         ?SUP(pp_http_sup, []),
         ?SUP(pp_console_sup, []),
-        ?WORKER(pp_metrics, []),
+        ?WORKER(pp_metrics, [MetricsConfig]),
         #{
             id => pp_roaming_downlink,
             start => {elli, start_link, [ElliConfig]},

--- a/src/state_channels/pp_sc_packet_handler.erl
+++ b/src/state_channels/pp_sc_packet_handler.erl
@@ -207,7 +207,6 @@ handle_packet_offer(DevAddr, Offer) ->
     Resp :: ok | {error, any()}
 ) -> ok.
 handle_offer_resp(Routing, Offer, Resp) ->
-    PubKeyBin = blockchain_state_channel_offer_v1:hotspot(Offer),
     {ok, NetIDs} =
         case Routing of
             {eui, _} = EUI ->
@@ -236,10 +235,10 @@ handle_offer_resp(Routing, Offer, Resp) ->
             {devaddr, _} -> packet
         end,
 
-    PayloadSize = blockchain_state_channel_offer_v1:payload_size(Offer),
+    PHash = blockchain_state_channel_offer_v1:packet_hash(Offer),
     lists:foreach(
         fun(NetID) ->
-            ok = pp_metrics:handle_offer(PubKeyBin, NetID, OfferType, Action, PayloadSize),
+            ok = pp_metrics:handle_offer(NetID, OfferType, Action, PHash),
 
             lager:debug(
                 [{action, Action}, {offer_type, OfferType}, {net_id, NetID}],


### PR DESCRIPTION
Insert or update a counter for every phash we see.

- unique_offers_cleanup_timer :: seconds
  - How often in seconds to scan the ets table for cleanup.
- unique_offers_window :: seconds
  - How long before Now are items considered unique.
  - **NOTE**: there's potential for packets to be double counted if
    there is an offer delivery past `unique_offers_window`.