### PR TITLE
Single shot http forwarding

### DIFF
--- a/src/pp_http_worker.erl
+++ b/src/pp_http_worker.erl
@@ -93,6 +93,14 @@ handle_call(_Msg, _From, State) ->
 
 handle_cast(
     {handle_packet, SCPacket, GatewayTime},
+    #state{send_data_timer = 0, shutdown_timer_ref = ShutdownTimerRef0} = State
+) ->
+    {ok, StateWithPacket} = do_handle_packet(SCPacket, GatewayTime, State),
+    ok = send_data(StateWithPacket),
+    {ok, ShutdownTimerRef1} = maybe_schedule_shutdown(ShutdownTimerRef0),
+    {noreply, State#state{shutdown_timer_ref = ShutdownTimerRef1}};
+handle_cast(
+    {handle_packet, SCPacket, GatewayTime},
     #state{
         should_shutdown = false,
         send_data_timer = Timeout,


### PR DESCRIPTION
With the dedupe window set to `0` we will not attempt to dedupe anything and send every message as soon as we see it.