### PR TITLE
Multiple protocol downlink pid contention

### DIFF
--- a/src/apis/pp_console_ws_manager.erl
+++ b/src/apis/pp_console_ws_manager.erl
@@ -143,7 +143,7 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 terminate(_Reason, _State) ->
-    ct:print("went down ~p : ~p", [?MODULE, _Reason]),
+    lager:warning("went down ~p : ~p", [?MODULE, _Reason]),
     ok.
 
 %% ------------------------------------------------------------------

--- a/src/apis/pp_console_ws_worker.erl
+++ b/src/apis/pp_console_ws_worker.erl
@@ -243,7 +243,7 @@ handle_message(?ORGANIZATION_TOPIC, ?WS_RCV_REFILL_BALANCE, Payload) ->
     lager:info("refill DC balance: ~p", [Payload]),
     ok;
 handle_message(?ORGANIZATION_TOPIC, ?WS_RCV_REFETCH_ADDRESS, Payload) ->
-    ct:print("sending address: ~p", [Payload]),
+    lager:info("sending address: ~p", [Payload]),
     ?MODULE:send_address(),
     ok;
 handle_message(?NET_ID_TOPIC, ?WS_RCV_KEEP_PURCHASING_NET_ID, #{<<"net_ids">> := NetIDs}) ->

--- a/src/pp_config.erl
+++ b/src/pp_config.erl
@@ -56,19 +56,12 @@
     protocol/1
 ]).
 
-%% downlink response ets
--export([
-    insert_transaction_id/3,
-    lookup_transaction_id/1
-]).
-
 %% Websocket API
 -export([ws_update_config/1]).
 
 -define(EUI_ETS, pp_config_join_ets).
 -define(DEVADDR_ETS, pp_config_routing_ets).
 -define(UDP_WORKER_ETS, pp_config_udp_worker_ets).
--define(TRANSACTION_ETS, pp_config_transaction_ets).
 
 -record(state, {
     filename :: testing | string()
@@ -388,26 +381,7 @@ init_ets() ->
         {write_concurrency, true},
         {read_concurrency, true}
     ]),
-    ?TRANSACTION_ETS = ets:new(?TRANSACTION_ETS, [
-        public,
-        named_table,
-        set,
-        {read_concurrency, true},
-        {write_concurrency, true}
-    ]),
     ok.
-
--spec insert_transaction_id(integer(), binary(), atom()) -> ok.
-insert_transaction_id(TransactionID, Endpoint, FlowType) ->
-    true = ets:insert(?TRANSACTION_ETS, {TransactionID, Endpoint, FlowType}),
-    ok.
-
--spec lookup_transaction_id(integer()) -> {ok, binary(), atom()} | {error, routing_not_found}.
-lookup_transaction_id(TransactionID) ->
-    case ets:lookup(?TRANSACTION_ETS, TransactionID) of
-        [] -> {error, routing_not_found};
-        [{_, Endpoint, FlowType}] -> {ok, Endpoint, FlowType}
-    end.
 
 -spec update_buying_devaddr(NetID :: integer(), BuyingActive :: boolean()) -> ok.
 update_buying_devaddr(NetID, BuyingActive) ->

--- a/src/pp_roaming_protocol.erl
+++ b/src/pp_roaming_protocol.erl
@@ -3,9 +3,7 @@
 %% Uplinking
 -export([
     make_uplink_payload/7,
-    select_best/1,
-    gateway_time/1,
-    handler_pid/1
+    select_best/1
 ]).
 
 %% Downlinking
@@ -21,7 +19,7 @@
     parse_uplink_token/1
 ]).
 
--export([new_packet/3]).
+-export([new_packet/2]).
 
 -define(NO_ROAMING_AGREEMENT, <<"NoRoamingAgreement">>).
 
@@ -45,7 +43,6 @@
     SCResp :: any()
 }.
 
--type transaction_id() :: integer().
 -type region() :: atom().
 -type token() :: binary().
 -type dest_url() :: binary().
@@ -56,8 +53,7 @@
 -record(packet, {
     sc_packet :: sc_packet(),
     gateway_time :: gateway_time(),
-    location :: pp_utils:location(),
-    handler_pid :: pid()
+    location :: pp_utils:location()
 }).
 -type packet() :: #packet{}.
 
@@ -73,24 +69,14 @@
 %% Uplink
 %% ------------------------------------------------------------------
 
--spec new_packet(SCPacket :: sc_packet(), GatewayTime :: gateway_time(), HandlerPid :: pid()) ->
-    #packet{}.
-new_packet(SCPacket, GatewayTime, HandlerPid) ->
+-spec new_packet(SCPacket :: sc_packet(), GatewayTime :: gateway_time()) -> #packet{}.
+new_packet(SCPacket, GatewayTime) ->
     PubKeyBin = blockchain_state_channel_packet_v1:hotspot(SCPacket),
     #packet{
         sc_packet = SCPacket,
         gateway_time = GatewayTime,
-        location = pp_utils:get_hotspot_location(PubKeyBin),
-        handler_pid = HandlerPid
+        location = pp_utils:get_hotspot_location(PubKeyBin)
     }.
-
--spec gateway_time(#packet{}) -> gateway_time().
-gateway_time(#packet{gateway_time = GWTime}) ->
-    GWTime.
-
--spec handler_pid(#packet{}) -> pid().
-handler_pid(#packet{handler_pid = HandlerPid}) ->
-    HandlerPid.
 
 -spec make_uplink_payload(
     NetID :: netid_num(),
@@ -112,13 +98,11 @@ make_uplink_payload(
 ) ->
     #packet{
         sc_packet = SCPacket,
-        gateway_time = GatewayTime,
-        handler_pid = HandlerPid
+        gateway_time = GatewayTime
     } = select_best(Uplinks),
     Packet = blockchain_state_channel_packet_v1:packet(SCPacket),
     PacketTime = blockchain_helium_packet_v1:timestamp(Packet),
     PubKeyBin = blockchain_state_channel_packet_v1:hotspot(SCPacket),
-    pg:join(PubKeyBin, HandlerPid),
 
     RoutingInfo = blockchain_helium_packet_v1:routing_info(Packet),
 
@@ -133,8 +117,7 @@ make_uplink_payload(
             {eui, DevEUI, _AppEUI} -> {'DevEUI', encode_deveui(DevEUI)}
         end,
 
-    Token = make_uplink_token(TransactionID, Region, PacketTime, Destination, FlowType),
-    ok = pp_roaming_downlink:insert_handler(TransactionID, HandlerPid),
+    Token = make_uplink_token(PubKeyBin, Region, PacketTime, Destination, FlowType),
 
     VersionBase =
         case ProtocolVersion of
@@ -199,7 +182,7 @@ handle_prstart_ans(#{
         <<"FNSULToken">> := Token
     } = DLMeta
 }) ->
-    {ok, TransactionID, Region, PacketTime, _, _} = parse_uplink_token(Token),
+    {ok, PubKeyBin, Region, PacketTime, _, _} = parse_uplink_token(Token),
 
     DownlinkPacket = blockchain_helium_packet_v1:new_downlink(
         pp_utils:hexstring_to_binary(Payload),
@@ -212,7 +195,7 @@ handle_prstart_ans(#{
 
     SCResp = blockchain_state_channel_response_v1:new(true, DownlinkPacket),
 
-    case pp_roaming_downlink:lookup_handler(TransactionID) of
+    case pp_roaming_downlink:lookup_handler(PubKeyBin) of
         {error, _} = Err -> Err;
         {ok, SCPid} -> {join_accept, {SCPid, SCResp}}
     end;
@@ -232,7 +215,7 @@ handle_prstart_ans(#{
     case parse_uplink_token(Token) of
         {error, _} = Err ->
             Err;
-        {ok, TransactionID, Region, PacketTime, _, _} ->
+        {ok, PubKeyBin, Region, PacketTime, _, _} ->
             DataRate = pp_lorawan:index_to_datarate(Region, DR),
 
             DownlinkPacket = blockchain_helium_packet_v1:new_downlink(
@@ -245,7 +228,7 @@ handle_prstart_ans(#{
 
             SCResp = blockchain_state_channel_response_v1:new(true, DownlinkPacket),
 
-            case pp_roaming_downlink:lookup_handler(TransactionID) of
+            case pp_roaming_downlink:lookup_handler(PubKeyBin) of
                 {error, _} = Err -> Err;
                 {ok, SCPid} -> {join_accept, {SCPid, SCResp}}
             end
@@ -310,7 +293,7 @@ handle_xmitdata_req(#{
     case parse_uplink_token(Token) of
         {error, _} = Err ->
             Err;
-        {ok, TransactionID, Region, PacketTime, DestURL, FlowType} ->
+        {ok, PubKeyBin, Region, PacketTime, DestURL, FlowType} ->
             DataRate1 = pp_lorawan:index_to_datarate(Region, DR1),
 
             Delay1 =
@@ -330,7 +313,7 @@ handle_xmitdata_req(#{
 
             SCResp = blockchain_state_channel_response_v1:new(true, DownlinkPacket),
 
-            case pp_roaming_downlink:lookup_handler(TransactionID) of
+            case pp_roaming_downlink:lookup_handler(PubKeyBin) of
                 {error, _} = Err -> Err;
                 {ok, SCPid} -> {downlink, PayloadResponse, {SCPid, SCResp}, {DestURL, FlowType}}
             end
@@ -363,7 +346,7 @@ handle_xmitdata_req(#{
     case parse_uplink_token(Token) of
         {error, _} = Err ->
             Err;
-        {ok, TransactionID, Region, PacketTime, DestURL, FlowType} ->
+        {ok, PubKeyBin, Region, PacketTime, DestURL, FlowType} ->
             DataRate = pp_lorawan:index_to_datarate(Region, DR),
 
             Delay1 =
@@ -395,7 +378,7 @@ handle_xmitdata_req(#{
 
             SCResp = blockchain_state_channel_response_v1:new(true, DownlinkPacket),
 
-            case pp_roaming_downlink:lookup_handler(TransactionID) of
+            case pp_roaming_downlink:lookup_handler(PubKeyBin) of
                 {error, _} = Err -> Err;
                 {ok, SCPid} -> {downlink, PayloadResponse, {SCPid, SCResp}, {DestURL, FlowType}}
             end
@@ -430,10 +413,16 @@ rx2_from_dlmetadata(_, _, _, _) ->
 %% Tokens
 %% ------------------------------------------------------------------
 
--spec make_uplink_token(transaction_id(), region(), non_neg_integer(), binary(), atom()) -> token().
-make_uplink_token(TransactionID, Region, PacketTime, DestURL, FlowType) ->
+-spec make_uplink_token(
+    PubKeyBin :: libp2p_crypto:pubkey_bin(),
+    Region :: region(),
+    PacketTime :: non_neg_integer(),
+    DestinationUrl :: binary(),
+    RoamingFlowType :: atom()
+) -> token().
+make_uplink_token(PubKeyBin, Region, PacketTime, DestURL, FlowType) ->
     Parts = [
-        erlang:integer_to_binary(TransactionID),
+        libp2p_crypto:bin_to_b58(PubKeyBin),
         erlang:atom_to_binary(Region),
         erlang:integer_to_binary(PacketTime),
         DestURL,
@@ -444,18 +433,19 @@ make_uplink_token(TransactionID, Region, PacketTime, DestURL, FlowType) ->
     pp_utils:binary_to_hexstring(Token1).
 
 -spec parse_uplink_token(token()) ->
-    {ok, transaction_id(), region(), non_neg_integer(), dest_url(), flow_type()} | {error, any()}.
+    {ok, libp2p_crypto:pubkey_bin(), region(), non_neg_integer(), dest_url(), flow_type()}
+    | {error, any()}.
 parse_uplink_token(<<"0x", Token/binary>>) ->
     parse_uplink_token(Token);
 parse_uplink_token(Token) ->
     Bin = pp_utils:hex_to_binary(Token),
     case binary:split(Bin, ?TOKEN_SEP, [global]) of
-        [TransactionIDBin, RegionBin, PacketTimeBin, DestURLBin, FlowTypeBin] ->
-            TransactionID = erlang:binary_to_integer(TransactionIDBin),
+        [B58, RegionBin, PacketTimeBin, DestURLBin, FlowTypeBin] ->
+            PubKeyBin = libp2p_crypto:b58_to_bin(erlang:binary_to_list(B58)),
             Region = erlang:binary_to_atom(RegionBin),
             PacketTime = erlang:binary_to_integer(PacketTimeBin),
             FlowType = erlang:binary_to_existing_atom(FlowTypeBin),
-            {ok, TransactionID, Region, PacketTime, DestURLBin, FlowType};
+            {ok, PubKeyBin, Region, PacketTime, DestURLBin, FlowType};
         _ ->
             {error, malformed_token}
     end.

--- a/src/pp_roaming_protocol.erl
+++ b/src/pp_roaming_protocol.erl
@@ -117,6 +117,8 @@ make_uplink_payload(
     } = select_best(Uplinks),
     Packet = blockchain_state_channel_packet_v1:packet(SCPacket),
     PacketTime = blockchain_helium_packet_v1:timestamp(Packet),
+    PubKeyBin = blockchain_state_channel_packet_v1:hotspot(SCPacket),
+    pg:join(PubKeyBin, HandlerPid),
 
     RoutingInfo = blockchain_helium_packet_v1:routing_info(Packet),
 

--- a/src/pp_sup.erl
+++ b/src/pp_sup.erl
@@ -71,7 +71,6 @@ init([]) ->
 
     ok = pp_multi_buy:init(),
     ok = pp_config:init_ets(),
-    ok = pp_roaming_downlink:init_ets(),
     ok = pp_utils:init_ets(),
     ok = pp_metrics:init_ets(),
 
@@ -102,6 +101,7 @@ init([]) ->
                 }
         end,
     ChildSpecs = [
+        ?WORKER(pg, []),
         ?WORKER(ru_poc_denylist, [POCDenyListArgs]),
         ?WORKER(pp_config, [ConfigFilename]),
         ?SUP(blockchain_sup, [BlockchainOpts]),

--- a/src/pp_udp_socket.erl
+++ b/src/pp_udp_socket.erl
@@ -20,7 +20,7 @@
 -type socket_port() :: inet:port_number().
 -type socket_info() :: {socket_address(), socket_port()}.
 
--export_type([socket/0, socket_address/0, socket_port/0]).
+-export_type([socket/0, socket_address/0, socket_port/0, socket_info/0]).
 
 -spec open(socket_info(), socket_info()) -> {ok, socket()}.
 open(Primary, Tee) ->

--- a/src/state_channels/pp_sc_packet_handler.erl
+++ b/src/state_channels/pp_sc_packet_handler.erl
@@ -80,7 +80,6 @@ handle_offer(Offer, _HandlerPid) ->
 handle_packet(SCPacket, PacketTime, Pid) ->
     Packet = blockchain_state_channel_packet_v1:packet(SCPacket),
     PubKeyBin = blockchain_state_channel_packet_v1:hotspot(SCPacket),
-    ok = pp_roaming_downlink:insert_handler(PubKeyBin, Pid),
 
     {PacketType, RoutingInfo} =
         case blockchain_helium_packet_v1:routing_info(Packet) of
@@ -125,6 +124,7 @@ handle_packet(SCPacket, PacketTime, Pid) ->
             ),
             Err;
         {ok, Matches} ->
+            ok = pp_roaming_downlink:insert_handler(PubKeyBin, Pid),
             lists:foreach(
                 fun(Match) ->
                     case Match of

--- a/src/state_channels/pp_sc_packet_handler.erl
+++ b/src/state_channels/pp_sc_packet_handler.erl
@@ -124,6 +124,7 @@ handle_packet(SCPacket, PacketTime, Pid) ->
             ),
             Err;
         {ok, Matches} ->
+            ct:print("sendingp packet to ~p", [Matches]),
             lists:foreach(
                 fun(Match) ->
                     case Match of

--- a/src/state_channels/pp_sc_packet_handler.erl
+++ b/src/state_channels/pp_sc_packet_handler.erl
@@ -80,6 +80,7 @@ handle_offer(Offer, _HandlerPid) ->
 handle_packet(SCPacket, PacketTime, Pid) ->
     Packet = blockchain_state_channel_packet_v1:packet(SCPacket),
     PubKeyBin = blockchain_state_channel_packet_v1:hotspot(SCPacket),
+    ok = pp_roaming_downlink:insert_handler(PubKeyBin, Pid),
 
     {PacketType, RoutingInfo} =
         case blockchain_helium_packet_v1:routing_info(Packet) of
@@ -124,7 +125,6 @@ handle_packet(SCPacket, PacketTime, Pid) ->
             ),
             Err;
         {ok, Matches} ->
-            ct:print("sendingp packet to ~p", [Matches]),
             lists:foreach(
                 fun(Match) ->
                     case Match of
@@ -204,12 +204,7 @@ handle_packet(SCPacket, PacketTime, Pid) ->
                                         PacketTime,
                                         PacketType
                                     ),
-                                    pp_http_worker:handle_packet(
-                                        WorkerPid,
-                                        SCPacket,
-                                        PacketTime,
-                                        Pid
-                                    )
+                                    pp_http_worker:handle_packet(WorkerPid, SCPacket, PacketTime)
                             end
                     end
                 end,

--- a/test/pp_grpc_SUITE.erl
+++ b/test/pp_grpc_SUITE.erl
@@ -136,7 +136,7 @@ grpc_join_net_id_packet_test(_Config) ->
     timer:sleep(1000),
     {ok, Pid} = pp_udp_sup:lookup_worker({PubKeyBin1, NetID}),
 
-    AddressPort = get_udp_worker_address_port(Pid),
+    AddressPort = pp_udp_worker:get_address_and_port(Pid),
     ?assertEqual({"3.3.3.3", 3333}, AddressPort),
 
     %% ------------------------------------------------------------
@@ -179,7 +179,7 @@ grpc_net_ids_map_packet_test(_Config) ->
         ok = grpcbox_client:send(Stream, EnvUp),
         timer:sleep(100),
         {ok, Pid} = pp_udp_sup:lookup_worker({PubKeyBin, NetID}),
-        get_udp_worker_address_port(Pid)
+        pp_udp_worker:get_address_and_port(Pid)
     end,
     ok = pp_config:load_config([
         #{
@@ -262,7 +262,7 @@ grpc_single_hotspot_multi_net_id_test(_Config) ->
         timer:sleep(100),
 
         {ok, Pid} = pp_udp_sup:lookup_worker({PubKeyBin, NetID}),
-        get_udp_worker_address_port(Pid)
+        pp_udp_worker:get_address_and_port(Pid)
     end,
     ok = pp_config:load_config([
         #{
@@ -495,21 +495,6 @@ grpc_multi_buy_packet_test(_Config) ->
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
-
-get_udp_worker_address_port(Pid) ->
-    {
-        state,
-        _Loc,
-        _PubKeyBin1,
-        _NetID,
-        Socket,
-        _PushData,
-        _ScPid,
-        _PullData,
-        _PullDataTimer,
-        _ShutdownTimer
-    } = sys:get_state(Pid),
-    pp_udp_socket:get_address(Socket).
 
 bin_to_int(Bin) ->
     pp_utils:hexstring_to_int(pp_utils:binary_to_hex(Bin)).

--- a/test/pp_lns.erl
+++ b/test/pp_lns.erl
@@ -280,77 +280,89 @@ handle(Req, Args) ->
 handle('POST', [<<"downlink">>], Req, Args) ->
     Forward = maps:get(forward, Args),
     Body = elli_request:body(Req),
-    #{<<"TransactionID">> := TransactionID} = Decoded = jsx:decode(Body),
+    Decoded = jsx:decode(Body),
 
-    %% SenderNetIDBin = maps:get(<<"SenderID">>, Decoded),
-    %% SenderNetID = pp_utils:hexstring_to_int(SenderNetIDBin),
-    FlowType =
-        case pp_config:lookup_transaction_id(TransactionID) of
-            {ok, _Endpoint, FT} ->
-                FT;
-            {error, _} ->
-                Forward ! {http_downlink_data_error, transaction_id_not_found}
-        end,
+    case maps:get(<<"DLMetaData">>, Decoded, undefined) of
+        undefined ->
+            {200, [], <<"result received">>};
+        #{<<"FNSULToken">> := Token} ->
+            {ok, _PubKeyBin, _Region, _PacketTime, _Address, FlowType} = pp_roaming_protocol:parse_uplink_token(
+                Token
+            ),
+            ct:print("handling packet with flow type: ~p", [FlowType]),
 
-    case FlowType of
-        async ->
-            Forward ! {http_downlink_data, Body},
-            Res = pp_roaming_downlink:handle(Req, Args),
-            ct:pal("Downlink handler resp: ~p", [Res]),
-            Forward ! {http_downlink_data_response, 200},
-            {200, [], <<>>};
-        sync ->
-            ct:pal("sync handling downlink:~n~p", [Decoded]),
-            Response = pp_roaming_downlink:handle(Req, Args),
+            case FlowType of
+                async ->
+                    Forward ! {http_downlink_data, Body},
+                    Res = pp_roaming_downlink:handle(Req, Args),
+                    ct:pal("Downlink handler resp: ~p", [Res]),
+                    Forward ! {http_downlink_data_response, 200},
+                    {200, [], <<>>};
+                sync ->
+                    ct:pal("sync handling downlink:~n~p", [Decoded]),
+                    Response = pp_roaming_downlink:handle(Req, Args),
 
-            %% ResponseBody = make_response_body(Decoded),
-            %% Response = {200, [], jsx:encode(ResponseBody)},
-            Forward ! {http_msg, Body, Req, Response},
-            Response
+                    %% ResponseBody = make_response_body(Decoded),
+                    %% Response = {200, [], jsx:encode(ResponseBody)},
+                    Forward ! {http_msg, Body, Req, Response},
+                    Response
+            end
     end;
 handle('POST', [<<"uplink">>], Req, Args) ->
     WaitTimeMs = maps:get(wait_ms, Args, 250),
     Forward = maps:get(forward, Args),
     Body = elli_request:body(Req),
-    #{<<"TransactionID">> := TransactionID} = jsx:decode(Body),
+    Decoded = jsx:decode(Body),
+    #{<<"MessageType">> := MessageType} = Decoded,
 
-    %% ReceiverNetIDBin = maps:get(<<"ReceiverID">>, Decoded),
-    %% ReceiverNetID = pp_utils:hexstring_to_int(ReceiverNetIDBin),
-    {ok, _, FlowType} = pp_config:lookup_transaction_id(TransactionID),
-
-    ResponseBody =
-        case maps:get(response, Args, undefined) of
-            undefined ->
-                make_response_body(jsx:decode(Body));
-            Resp ->
-                ct:pal("Using canned response: ~p", [Resp]),
-                Resp
-        end,
-
-    case FlowType of
-        async ->
-            Response = {200, [], <<>>},
+    case MessageType of
+        <<"XmitDataAns">> ->
             Forward ! {http_uplink_data, Body},
             Forward ! {http_uplink_data_response, 200},
-            ct:print("received uplink -------"),
-            spawn(fun() ->
-                timer:sleep(WaitTimeMs),
-                ct:print("sending downlink --------"),
-                Res = hackney:post(
-                    <<"http://127.0.0.1:3003/downlink">>,
-                    [{<<"Host">>, <<"localhost">>}],
-                    jsx:encode(ResponseBody),
-                    [with_body]
-                ),
-                ct:pal("Downlink Res: ~p", [Res])
-            end),
 
-            Response;
-        sync ->
-            Response = {200, [], jsx:encode(ResponseBody)},
-            Forward ! {http_msg, Body, Req, Response},
+            {200, [], <<"XmitDataAns OK">>};
+        _ ->
+            #{
+                <<"TransactionID">> := _TransactionID,
+                <<"ULMetaData">> := #{<<"FNSULToken">> := Token}
+            } = Decoded,
 
-            Response
+            {ok, _PubKeyBin, _Region, _PacketTime, _Address, FlowType} = pp_roaming_protocol:parse_uplink_token(
+                Token
+            ),
+
+            ResponseBody =
+                case maps:get(response, Args, undefined) of
+                    undefined ->
+                        make_response_body(jsx:decode(Body));
+                    Resp ->
+                        ct:pal("Using canned response: ~p", [Resp]),
+                        Resp
+                end,
+
+            case FlowType of
+                async ->
+                    Response = {200, [], <<>>},
+                    Forward ! {http_uplink_data, Body},
+                    Forward ! {http_uplink_data_response, 200},
+                    spawn(fun() ->
+                        timer:sleep(WaitTimeMs),
+                        Res = hackney:post(
+                            <<"http://127.0.0.1:3003/downlink">>,
+                            [{<<"Host">>, <<"localhost">>}],
+                            jsx:encode(ResponseBody),
+                            [with_body]
+                        ),
+                        ct:pal("Downlink Res: ~p", [Res])
+                    end),
+
+                    Response;
+                sync ->
+                    Response = {200, [], jsx:encode(ResponseBody)},
+                    Forward ! {http_msg, Body, Req, Response},
+
+                    Response
+            end
     end.
 
 handle_event(_Event, _Data, _Args) ->

--- a/test/pp_roaming_protocol_SUITE.erl
+++ b/test/pp_roaming_protocol_SUITE.erl
@@ -39,7 +39,7 @@ all() ->
 %% TEST CASE SETUP
 %%--------------------------------------------------------------------
 init_per_testcase(_TestCase, Config) ->
-    ok = pp_roaming_downlink:init_ets(),
+    {ok, _} = pg:start_link(),
     Config.
 %% test_utils:init_per_testcase(TestCase, Config).
 
@@ -55,11 +55,13 @@ end_per_testcase(_TestCase, _Config) ->
 %%--------------------------------------------------------------------
 
 class_c_downlink_test(_Config) ->
-    TransactionID = 2176,
-    pp_roaming_downlink:insert_handler(TransactionID, self()),
+    #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+
+    pp_roaming_downlink:insert_handler(PubKeyBin, self()),
 
     Token = pp_roaming_protocol:make_uplink_token(
-        TransactionID,
+        PubKeyBin,
         'US915',
         erlang:system_time(millisecond),
         <<"www.example.com">>,
@@ -90,11 +92,13 @@ class_c_downlink_test(_Config) ->
     ok.
 
 chirpstack_join_accept_test(_Config) ->
+    #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
     TransactionID = 473719436,
-    pp_roaming_downlink:insert_handler(TransactionID, self()),
+    pp_roaming_downlink:insert_handler(PubKeyBin, self()),
 
     Token = pp_roaming_protocol:make_uplink_token(
-        TransactionID,
+        PubKeyBin,
         'US915',
         erlang:system_time(millisecond),
         <<"www.example.com">>,
@@ -137,12 +141,14 @@ chirpstack_join_accept_test(_Config) ->
     ok.
 
 rx1_timestamp_test(_Config) ->
-    TransactionID = 17,
-    ok = pp_roaming_downlink:insert_handler(TransactionID, self()),
+    #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+
+    ok = pp_roaming_downlink:insert_handler(PubKeyBin, self()),
 
     PacketTime = 0,
     Token = pp_roaming_protocol:make_uplink_token(
-        TransactionID,
+        PubKeyBin,
         'US915',
         PacketTime,
         <<"www.example.com">>,
@@ -192,8 +198,10 @@ rx1_timestamp_test(_Config) ->
     ok.
 
 rx1_downlink_test(_Config) ->
-    TransactionID = 17,
-    ok = pp_roaming_downlink:insert_handler(TransactionID, self()),
+    #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+
+    ok = pp_roaming_downlink:insert_handler(PubKeyBin, self()),
 
     Payload = <<"0x60c04e26e020000000a754ba934840c3bc120989b532ee4613e06e3dd5d95d9d1ceb9e20b1f2">>,
     RXDelay = 2,
@@ -201,7 +209,7 @@ rx1_downlink_test(_Config) ->
     DataRate = 10,
 
     Token = pp_roaming_protocol:make_uplink_token(
-        TransactionID,
+        PubKeyBin,
         'US915',
         erlang:system_time(millisecond),
         <<"www.example.com">>,
@@ -247,11 +255,13 @@ rx1_downlink_test(_Config) ->
     ok.
 
 rx2_downlink_test(_Config) ->
-    TransactionID = 17,
-    ok = pp_roaming_downlink:insert_handler(TransactionID, self()),
+    #{public := PubKey} = libp2p_crypto:generate_keys(ecc_compact),
+    PubKeyBin = libp2p_crypto:pubkey_to_bin(PubKey),
+
+    ok = pp_roaming_downlink:insert_handler(PubKeyBin, self()),
 
     Token = pp_roaming_protocol:make_uplink_token(
-        TransactionID,
+        PubKeyBin,
         'US915',
         erlang:system_time(millisecond),
         <<"www.example.com">>,

--- a/test/pp_udp_worker_SUITE.erl
+++ b/test/pp_udp_worker_SUITE.erl
@@ -32,7 +32,6 @@
     net_id :: non_neg_integer(),
     socket :: pp_udp_socket:socket(),
     push_data = #{} :: #{binary() => {binary(), reference()}},
-    handler_pids :: list(pid()),
     pull_data :: {reference(), binary()} | undefined,
     pull_data_timer :: non_neg_integer(),
     shutdown_timer :: {Timeout :: non_neg_integer(), Timer :: reference()}
@@ -141,7 +140,7 @@ push_data_no_location(Config) ->
     %% Chekcing that the push data cache is empty as we should have gotten the push ack
     ok = test_utils:wait_until(fun() ->
         State = sys:get_state(WorkerPid),
-        State#state.push_data == #{} andalso lists:member(self(), State#state.handler_pids)
+        State#state.push_data == #{}
     end),
 
     ok.
@@ -196,7 +195,7 @@ push_data_with_location(Config) ->
     %% Chekcing that the push data cache is empty as we should have gotten the push ack
     ok = test_utils:wait_until(fun() ->
         State = sys:get_state(WorkerPid),
-        State#state.push_data == #{} andalso lists:member(self(), State#state.handler_pids)
+        State#state.push_data == #{}
     end),
 
     gen_server:stop(WorkerPid),
@@ -300,7 +299,7 @@ delay_push_data(Config) ->
     %% Checking that the push data cache is empty as we should have gotten the push ack
     ok = test_utils:wait_until(fun() ->
         State = sys:get_state(WorkerPid),
-        State#state.push_data == #{} andalso lists:member(self(), State#state.handler_pids)
+        State#state.push_data == #{}
     end),
 
     ok.
@@ -345,7 +344,7 @@ missing_push_data_ack(Config) ->
     %% Checking that the push data cache is full as we should have _not_ gotten the push ack
     ok = test_utils:wait_until(fun() ->
         State = sys:get_state(WorkerPid),
-        State#state.push_data == #{} andalso lists:member(self(), State#state.handler_pids)
+        State#state.push_data == #{}
     end),
 
     ok.
@@ -549,12 +548,12 @@ multi_hotspots(Config) ->
 
     ok = test_utils:wait_until(fun() ->
         State1 = sys:get_state(WorkerPid1),
-        State1#state.push_data == #{} andalso lists:member(self(), State1#state.handler_pids)
+        State1#state.push_data == #{}
     end),
 
     ok = test_utils:wait_until(fun() ->
         State2 = sys:get_state(WorkerPid2),
-        State2#state.push_data == #{} andalso lists:member(self(), State2#state.handler_pids)
+        State2#state.push_data == #{}
     end),
 
     _ = gen_server:stop(WorkerPid2),


### PR DESCRIPTION
UDP workers were using a FIFO queue to downlink.
Http workers had pids attached to transaction ids.

If a gateway was being used for a multiple protocols, there was a chance a UDP downlink could come along and use a PID that was the only PID an Http downlink would know how to use.

**Fix**:
When a packet comes in, the HandlerPid is registered with `pg` (so we don't have to worry about cleanup).
When a downlink comes in through UDP or HTTP, they will ask `pg` for a pid registered to a pubkeybin and use that regardless of order.